### PR TITLE
Add support for reading the git config

### DIFF
--- a/src/Command/Config/Get.php
+++ b/src/Command/Config/Get.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * This file is part of SebastianFeldmann\Git.
+ *
+ * (c) Sebastian Feldmann <sf@sebastian-feldmann.info>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace SebastianFeldmann\Git\Command\Config;
+
+use SebastianFeldmann\Git\Command\Base;
+
+/**
+ * Class Get
+ *
+ * @package SebastianFeldmann\Git
+ * @author  Sebastian Feldmann <sf@sebastian-feldmann.info>
+ * @link    https://github.com/sebastianfeldmann/git
+ */
+class Get extends Base
+{
+    /**
+     * The name of the configuration key to get
+     *
+     * @var string
+     */
+    private $name;
+
+    /**
+     * The name of the configuration key to get.
+     *
+     * @param string $name
+     * @return \SebastianFeldmann\Git\Command\Config\Get
+     */
+    public function name(string $name) : Get
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    /**
+     * Return the command to execute.
+     *
+     * @return string
+     */
+    protected function getGitCommand() : string
+    {
+        return 'config --get ' .  escapeshellarg($this->name);
+    }
+}

--- a/src/Operator/Config.php
+++ b/src/Operator/Config.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * This file is part of SebastianFeldmann\Git.
+ *
+ * (c) Sebastian Feldmann <sf@sebastian.feldmann.info>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace SebastianFeldmann\Git\Operator;
+
+use SebastianFeldmann\Cli\Command\Runner\Result;
+use SebastianFeldmann\Git\Command\Config\Get;
+
+/**
+ * Class Config
+ *
+ * @package SebastianFeldmann\Git
+ * @author  Sebastian Feldmann <sf@sebastian-feldmann.info>
+ * @link    https://github.com/sebastianfeldmann/git
+ */
+class Config extends Base
+{
+    /**
+     * Does git have a configuration key
+     *
+     * @param  string $name
+     * @return boolean
+     */
+    public function has(string $name) : bool
+    {
+        $result = $this->configCommand($name);
+
+        return $result->isSuccessful();
+    }
+
+
+    /**
+     * Get a configuration key value
+     *
+     * @param  string $name
+     * @return string
+     */
+    public function get(string $name) : string
+    {
+        $result = $this->configCommand($name);
+
+        return $result->getBufferedOutput()[0];
+    }
+
+    /**
+     * Run the get config command
+     *
+     * @param string $name
+     * @return \SebastianFeldmann\Cli\Command\Runner\Result
+     */
+    private function configCommand(string $name) : Result
+    {
+        $cmd = (new Get($this->repo->getRoot()));
+        $cmd->name($name);
+
+        $result = $this->runner->run($cmd);
+
+        return $result;
+    }
+}

--- a/src/Repository.php
+++ b/src/Repository.php
@@ -162,6 +162,16 @@ class Repository
     }
 
     /**
+     * Get config operator.
+     *
+     * @return \SebastianFeldmann\Git\Operator\Config
+     */
+    public function getConfigOperator() : Operator\Config
+    {
+        return $this->getOperator('Config');
+    }
+
+    /**
      * Return requested operator.
      *
      * @param  string $name

--- a/tests/git/Command/Config/GetTest.php
+++ b/tests/git/Command/Config/GetTest.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * This file is part of SebastianFeldmann\Git.
+ *
+ * (c) Sebastian Feldmann <sf@sebastian-feldmann.info>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace SebastianFeldmann\Git\Command\Log;
+
+use SebastianFeldmann\Git\Command\Config\Get;
+
+/**
+ * Class GetTest
+ *
+ * @package SebastianFeldmann\Git
+ * @author  Sebastian Feldmann <sf@sebastian-feldmann.info>
+ * @link    https://github.com/sebastianfeldmann/git
+ */
+class GetTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * Tests Get::getGitCommand
+     */
+    public function testDefault()
+    {
+        $cmd = new Get();
+        $exe = $cmd->name('user.name')->getCommand();
+
+        $this->assertEquals("git config --get 'user.name'", $exe);
+    }
+}

--- a/tests/git/Operator/ConfigTest.php
+++ b/tests/git/Operator/ConfigTest.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * This file is part of SebastianFeldmann\Git.
+ *
+ * (c) Sebastian Feldmann <sf@sebastian-feldmann.info>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace SebastianFeldmann\Git\Operator;
+
+use SebastianFeldmann\Cli\Command\Result as CommandResult;
+use SebastianFeldmann\Cli\Command\Runner\Result as RunnerResult;
+
+/**
+ * Class ConfigTest
+ *
+ * @package SebastianFeldmann\Git
+ * @author  Sebastian Feldmann <sf@sebastian-feldmann.info>
+ * @link    https://github.com/sebastianfeldmann/git
+ */
+class ConfigTest extends OperatorTest
+{
+    /**
+     * Tests Config::has
+     */
+    public function testHas()
+    {
+        $repo = $this->getRepoMock();
+        $runner = $this->getRunnerMock();
+        $cmd = new CommandResult('git ...', 0, '#');
+        $result = new RunnerResult($cmd);
+
+        $repo->method('getRoot')->willReturn(realpath(__FILE__ . '/../../..'));
+        $runner->method('run')->willReturn($result);
+
+        $config = new Config($runner, $repo);
+        $hasKey = $config->has('core.commentchar');
+
+        $this->assertEquals(true, $hasKey);
+    }
+
+    /**
+     * Tests Config::get
+     */
+    public function testGet()
+    {
+        $repo = $this->getRepoMock();
+        $runner = $this->getRunnerMock();
+        $cmd = new CommandResult('git ...', 0, '#');
+        $result = new RunnerResult($cmd);
+
+        $repo->method('getRoot')->willReturn(realpath(__FILE__ . '/../../..'));
+        $runner->method('run')->willReturn($result);
+
+        $config = new Config($runner, $repo);
+        $value = $config->get('core.commentchar');
+
+        $this->assertEquals('#', $value);
+    }
+}

--- a/tests/git/RepositoryTest.php
+++ b/tests/git/RepositoryTest.php
@@ -138,4 +138,15 @@ class RepositoryTest extends \PHPUnit\Framework\TestCase
 
         $this->assertTrue(is_a($operator, '\\SebastianFeldmann\\Git\\Operator\\Log'));
     }
+
+    /**
+     * Tests Repository::getConfigOperator
+     */
+    public function testGetConfigOperator()
+    {
+        $repository = new Repository($this->repo->getPath());
+        $operator   = $repository->getConfigOperator();
+
+        $this->assertTrue(is_a($operator, '\\SebastianFeldmann\\Git\\Operator\\Config'));
+    }
 }


### PR DESCRIPTION
Currently there's no way to work out what a config variable should be
with git simply by reading text files. This is because the git exec
reads from different places depending on what prefix was during build.

This will allow us to use the binary to resolve that information.

This is important because there is a `core.commentChar` configuration variable which affects how commit messages should be parsed.

Please note I've not added any `@since` tags on the added classes as they're in an unreleased state. As such I wasn't sure what go in there.