### PR TITLE
Allow ignoring comment lines in commits from files

### DIFF
--- a/src/CommitMessage.php
+++ b/src/CommitMessage.php
@@ -22,34 +22,84 @@ class CommitMessage
     /**
      * Commit Message content
      *
+     * This includes lines that are comments
+     *
      * @var string
      */
-    private $content;
+    private $rawContent;
 
     /**
      * Content split lines
+     *
+     * This includes lines that are comments
+     *
+     * @var string[]
+     */
+    private $rawLines;
+
+    /**
+     * Amount of lines
+     *
+     * This includes lines that are comments
+     *
+     * @var int
+     */
+    private $rawLineCount;
+
+    /**
+     * The comment character
+     *
+     * Null would indicate the comment character is not set for this commit. A comment character might be null if this
+     * commit came from a message stored in the repository, it would be populated if it came from a commit-msg hook,
+     * where the commit message can still contain comments.
+     *
+     * @var string|null
+     */
+    private $commentCharacter;
+
+    /**
+     * Get the lines
+     *
+     * This excludes the lines which are comments
      *
      * @var string[]
      */
     private $lines;
 
     /**
-     * Amount of lines
+     * Get the number of lines
+     *
+     * This excludes lines which are comments
      *
      * @var int
      */
     private $lineCount;
 
     /**
+     * Commit Message content
+     *
+     * This excludes lines that are comments
+     *
+     * @var string
+     */
+    private $content;
+
+    /**
      * CommitMessage constructor.
      *
-     * @param string $content
+     * @param string      $content
+     * @param string|null $commentCharacter
      */
-    public function __construct(string $content)
+    public function __construct(string $content, string $commentCharacter = null)
     {
-        $this->content   = $content;
-        $this->lines     = empty($content) ? [] : preg_split("/\\r\\n|\\r|\\n/", $content);
+        $this->rawContent   = $content;
+        $this->rawLines     = empty($content) ? [] : preg_split("/\\r\\n|\\r|\\n/", $content);
+        $this->rawLineCount = count($this->rawLines);
+
+        $this->commentCharacter = $commentCharacter;
+        $this->lines = $this->getContentLines($this->rawLines, $commentCharacter);
         $this->lineCount = count($this->lines);
+        $this->content = implode(PHP_EOL, $this->lines);
     }
 
     /**
@@ -65,31 +115,37 @@ class CommitMessage
     /**
      * Get complete commit message content.
      *
+     * This includes lines that are comments
+     *
      * @return string
      */
     public function getContent() : string
     {
-        return $this->content;
+        return $this->rawContent;
     }
 
     /**
      * Return all lines.
      *
+     * This includes lines that are comments
+     *
      * @return array
      */
     public function getLines() : array
     {
-        return $this->lines;
+        return $this->rawLines;
     }
 
     /**
      * Return line count.
      *
+     * This includes lines that are comments
+     *
      * @return int
      */
     public function getLineCount() : int
     {
-        return $this->lineCount;
+        return $this->rawLineCount;
     }
 
     /**
@@ -100,7 +156,7 @@ class CommitMessage
      */
     public function getLine(int $index) : string
     {
-        return isset($this->lines[$index]) ? $this->lines[$index] : '';
+        return isset($this->rawLines[$index]) ? $this->rawLines[$index] : '';
     }
 
     /**
@@ -134,16 +190,52 @@ class CommitMessage
     }
 
     /**
+     * Get the comment character
+     *
+     * Null would indicate the comment character is not set for this commit. A comment character might be null if this
+     * commit came from a message stored in the repository, it would be populated if it came from a commit-msg hook.
+     *
+     * @return null|string
+     */
+    public function getCommentCharacter()
+    {
+        return $this->commentCharacter;
+    }
+
+    /**
+     * Get the lines that are not comments
+     *
+     * Null comment character indicates no comment character.
+     *
+     * @param  array       $rawLines
+     * @param  string|null $commentCharacter
+     * @return string[]
+     */
+    private function getContentLines(array $rawLines, string $commentCharacter = null) : array {
+        $lines = [];
+
+        foreach($rawLines as $line) {
+            if(!isset($line{0}) || $line{0} !== $commentCharacter) {
+                $lines[] = $line;
+            }
+        }
+
+        return $lines;
+    }
+
+    /**
      * Create CommitMessage from file.
      *
      * @param  string $path
+     * @param  string|null $commentCharacter
      * @return \SebastianFeldmann\Git\CommitMessage
      */
-    public static function createFromFile(string $path) : CommitMessage
+    public static function createFromFile(string $path, $commentCharacter = '#') : CommitMessage
     {
         if (!file_exists($path)) {
             throw new \RuntimeException('Commit message file not found');
         }
-        return new CommitMessage(file_get_contents($path));
+
+        return new CommitMessage(file_get_contents($path), $commentCharacter);
     }
 }

--- a/tests/files/git/message/valid-with-comments.txt
+++ b/tests/files/git/message/valid-with-comments.txt
@@ -1,0 +1,18 @@
+This is a valid dummy commit Message
+
+It contains a subject line and some body lines.
+Subject and body are separated by a blank line.
+No body line is longer than 72 characters.
+Subject starts with a capital letter and doesn't end
+with a period.
+
+# Please enter the commit message for your changes. Lines starting
+# with '#' will be ignored, and an empty message aborts the commit.
+# On branch master
+# Changes to be committed:
+#	new file:   gs
+#	new file:   rgfar
+#	new file:   tgberyherbt
+#	new file:   w
+#	new file:   src/somefilename/somefilename/somefilename/somefilename/somefilename/somefilename/somefilename/somefilename/changed file.txt
+#


### PR DESCRIPTION
When git is creating a commit, the message it reads from a file does
not include the lines beginning with a comment character. This means
that the commit files that you get passed with a git commit message
hook is not exactly what will appear in git.

The comment character in versions of git later than 1.8.2 is
configurable, in versions prior to that it's always '#'.

In this implementation we do not preserve the comment lines at all.