### PR TITLE
Stop config::has() throwing exception on missing

### DIFF
--- a/src/Operator/Config.php
+++ b/src/Operator/Config.php
@@ -9,6 +9,7 @@
  */
 namespace SebastianFeldmann\Git\Operator;
 
+use RuntimeException;
 use SebastianFeldmann\Cli\Command\Runner\Result;
 use SebastianFeldmann\Git\Command\Config\Get;
 
@@ -30,7 +31,11 @@ class Config extends Base
      */
     public function has(string $name) : bool
     {
-        $result = $this->configCommand($name);
+        try {
+            $result = $this->configCommand($name);
+        } catch (RuntimeException $exception) {
+            return false;
+        }
 
         return $result->isSuccessful();
     }

--- a/tests/git/Operator/ConfigTest.php
+++ b/tests/git/Operator/ConfigTest.php
@@ -9,6 +9,7 @@
  */
 namespace SebastianFeldmann\Git\Operator;
 
+use RuntimeException;
 use SebastianFeldmann\Cli\Command\Result as CommandResult;
 use SebastianFeldmann\Cli\Command\Runner\Result as RunnerResult;
 
@@ -39,6 +40,30 @@ class ConfigTest extends OperatorTest
         $hasKey = $config->has('core.commentchar');
 
         $this->assertEquals(true, $hasKey);
+    }
+
+    /**
+     * Tests Config::has
+     */
+    public function testHasNot()
+    {
+        $repo      = $this->getRepoMock();
+        $runner    = $this->getRunnerMock();
+        $exception = new RuntimeException(
+            'Command failed: git config \'core.commentchar\'' . PHP_EOL
+            . '  exit-code: 1' . PHP_EOL
+            . '  message:   ' . PHP_EOL,
+            1
+        );
+
+        $repo->method('getRoot')->willReturn(realpath(__FILE__ . '/../../..'));
+        $runner->method('run')
+               ->will($this->throwException($exception));
+
+        $config = new Config($runner, $repo);
+        $hasKey = $config->has('core.commentchar');
+
+        $this->assertEquals(false, $hasKey);
     }
 
     /**


### PR DESCRIPTION
This function is a helper to make it nicer to check if a configuration
key exists. It's supposed to return true or false based on if the
config key exists or not.

When git tells you if a config key does not exist it has a return code
of `1`. This is a failure status code, so we throw an exception, we
need to handle that and turn it into something more friendly.