### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,14 @@ language: php
 php:
   - 7.0
   - 7.1
+  - 7.2
+  - 7.3
 
 before_script:
-  - composer self-update
   - composer install --no-interaction --prefer-source
-  - wget https://phar.phpunit.de/phpunit-6.5.9.phar
 
 script:
-  - php phpunit-6.5.9.phar
+  - vendor/bin/phpunit
 
 after_success:
   - wget https://scrutinizer-ci.com/ocular.phar

--- a/composer.json
+++ b/composer.json
@@ -19,9 +19,17 @@
       "SebastianFeldmann\\Git\\": "src/"
     }
   },
+  "autoload-dev": {
+    "psr-4": {
+      "SebastianFeldmann\\Git\\": "tests/"
+    }
+  },
   "require": {
     "php": ">=7.0.0",
     "sebastianfeldmann/cli": "^2.0.0"
+  },
+  "require-dev": {
+    "phpunit/phpunit": "^6.5"
   },
   "extra": {
     "branch-alias": {

--- a/tests/git/Command/BaseTest.php
+++ b/tests/git/Command/BaseTest.php
@@ -10,6 +10,7 @@
 namespace SebastianFeldmann\Git\Command;
 
 use SebastianFeldmann\Git\Command\Log\ChangedFiles;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class BaseTest
@@ -19,7 +20,7 @@ use SebastianFeldmann\Git\Command\Log\ChangedFiles;
  * @link    https://github.com/sebastianfeldmann/git
  * @since   Class available since Release 0.9.0
  */
-class BaseTest extends \PHPUnit\Framework\TestCase
+class BaseTest extends TestCase
 {
     /**
      * Tests Base::__toString

--- a/tests/git/Command/Config/GetTest.php
+++ b/tests/git/Command/Config/GetTest.php
@@ -9,6 +9,8 @@
  */
 namespace SebastianFeldmann\Git\Command\Config;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Class GetTest
  *
@@ -17,7 +19,7 @@ namespace SebastianFeldmann\Git\Command\Config;
  * @link    https://github.com/sebastianfeldmann/git
  * @since   Class available since Release 1.0.2
  */
-class GetTest extends \PHPUnit\Framework\TestCase
+class GetTest extends TestCase
 {
     /**
      * Tests Get::getGitCommand

--- a/tests/git/Command/Config/ListSettings/MapSettingsTest.php
+++ b/tests/git/Command/Config/ListSettings/MapSettingsTest.php
@@ -9,6 +9,8 @@
  */
 namespace SebastianFeldmann\Git\Command\Config\ListSettings;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Class MapSettingsTest
  *
@@ -17,7 +19,7 @@ namespace SebastianFeldmann\Git\Command\Config\ListSettings;
  * @link    https://github.com/sebastianfeldmann/git
  * @since   Class available since Release 1.0.8
  */
-class MapSettingsTest extends \PHPUnit\Framework\TestCase
+class MapSettingsTest extends TestCase
 {
     /**
      * Tests MapSettings::format

--- a/tests/git/Command/Config/ListSettingsTest.php
+++ b/tests/git/Command/Config/ListSettingsTest.php
@@ -9,6 +9,8 @@
  */
 namespace SebastianFeldmann\Git\Command\Config;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Class ListSettingsTest
  *
@@ -17,7 +19,7 @@ namespace SebastianFeldmann\Git\Command\Config;
  * @link    https://github.com/sebastianfeldmann/git
  * @since   Class available since Release 1.0.8
  */
-class ListSettingsTest extends \PHPUnit\Framework\TestCase
+class ListSettingsTest extends TestCase
 {
     /**
      * Tests ListSettings::getGitCommand

--- a/tests/git/Command/Describe/GetCurrentTagTest.php
+++ b/tests/git/Command/Describe/GetCurrentTagTest.php
@@ -9,6 +9,8 @@
  */
 namespace SebastianFeldmann\Git\Command\Describe;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Class GetCurrentTagTest
  *
@@ -17,7 +19,7 @@ namespace SebastianFeldmann\Git\Command\Describe;
  * @link    https://github.com/sebastianfeldmann/git
  * @since   Class available since Release 1.0.8
  */
-class GetCurrentTagTest extends \PHPUnit\Framework\TestCase
+class GetCurrentTagTest extends TestCase
 {
     /**
      * Tests GetCurrentTag::getGitCommand

--- a/tests/git/Command/Diff/Compare/FullDiffListTest.php
+++ b/tests/git/Command/Diff/Compare/FullDiffListTest.php
@@ -11,6 +11,7 @@ namespace SebastianFeldmann\Git\Command\Diff\Compare;
 
 use SebastianFeldmann\Git\Diff\File;
 use SebastianFeldmann\Git\Diff\Line;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class FullDiffListTest
@@ -19,7 +20,7 @@ use SebastianFeldmann\Git\Diff\Line;
  * @link    https://github.com/sebastianfeldmann/git
  * @since   Class available since Release 1.2.0
  */
-class FullDiffListTest extends \PHPUnit\Framework\TestCase
+class FullDiffListTest extends TestCase
 {
     /**
      * Tests FullDiffList::format
@@ -42,9 +43,9 @@ class FullDiffListTest extends \PHPUnit\Framework\TestCase
         $formatter = new FullDiffList();
         $files     = $formatter->format($output);
 
-        $this->assertEquals(1, count($files));
+        $this->assertCount(1, $files);
         $this->assertEquals('created', $files[0]->getOperation());
-        $this->assertEquals(4, count($files[0]->getChanges()[0]->getLines()));
+        $this->assertCount(4, $files[0]->getChanges()[0]->getLines());
         $this->assertEquals(Line::ADDED, $files[0]->getChanges()[0]->getLines()[0]->getOperation());
     }
 
@@ -73,9 +74,9 @@ class FullDiffListTest extends \PHPUnit\Framework\TestCase
         $formatter = new FullDiffList();
         $files     = $formatter->format($output);
 
-        $this->assertEquals(1, count($files));
+        $this->assertCount(1, $files);
         $this->assertEquals('created', $files[0]->getOperation());
-        $this->assertEquals(5, count($files[0]->getChanges()[0]->getLines()));
+        $this->assertCount(5, $files[0]->getChanges()[0]->getLines());
         $this->assertEquals(Line::ADDED, $files[0]->getChanges()[0]->getLines()[0]->getOperation());
     }
 
@@ -100,9 +101,9 @@ class FullDiffListTest extends \PHPUnit\Framework\TestCase
         $formatter = new FullDiffList();
         $files     = $formatter->format($output);
 
-        $this->assertEquals(1, count($files));
+        $this->assertCount(1, $files);
         $this->assertEquals('deleted', $files[0]->getOperation());
-        $this->assertEquals(4, count($files[0]->getChanges()[0]->getLines()));
+        $this->assertCount(4, $files[0]->getChanges()[0]->getLines());
     }
 
     /**
@@ -128,9 +129,9 @@ class FullDiffListTest extends \PHPUnit\Framework\TestCase
         $formatter = new FullDiffList();
         $files     = $formatter->format($output);
 
-        $this->assertEquals(1, count($files));
+        $this->assertCount(1, $files);
         $this->assertEquals('renamed', $files[0]->getOperation());
-        $this->assertEquals(4, count($files[0]->getChanges()[0]->getLines()));
+        $this->assertCount(4, $files[0]->getChanges()[0]->getLines());
     }
 
     /**
@@ -153,9 +154,9 @@ class FullDiffListTest extends \PHPUnit\Framework\TestCase
         $formatter = new FullDiffList();
         $files     = $formatter->format($output);
 
-        $this->assertEquals(1, count($files));
+        $this->assertCount(1, $files);
         $this->assertEquals('modified', $files[0]->getOperation());
-        $this->assertEquals(4, count($files[0]->getChanges()[0]->getLines()));
+        $this->assertCount(4, $files[0]->getChanges()[0]->getLines());
     }
 
     /**
@@ -180,11 +181,11 @@ class FullDiffListTest extends \PHPUnit\Framework\TestCase
         $formatter = new FullDiffList();
         $files     = $formatter->format($output);
 
-        $this->assertEquals(1, count($files));
+        $this->assertCount(1, $files);
         $this->assertEquals('modified', $files[0]->getOperation());
-        $this->assertEquals(2, count($files[0]->getChanges()));
-        $this->assertEquals(3, count($files[0]->getChanges()[0]->getLines()));
-        $this->assertEquals(2, count($files[0]->getChanges()[1]->getLines()));
+        $this->assertCount(2, $files[0]->getChanges());
+        $this->assertCount(3, $files[0]->getChanges()[0]->getLines());
+        $this->assertCount(2, $files[0]->getChanges()[1]->getLines());
     }
 
     /**
@@ -218,10 +219,10 @@ class FullDiffListTest extends \PHPUnit\Framework\TestCase
         $formatter = new FullDiffList();
         $files     = $formatter->format($output);
 
-        $this->assertEquals(2, count($files));
+        $this->assertCount(2, $files);
         $this->assertEquals('modified', $files[0]->getOperation());
-        $this->assertEquals(4, count($files[0]->getChanges()[0]->getLines()));
+        $this->assertCount(4, $files[0]->getChanges()[0]->getLines());
         $this->assertEquals('created', $files[1]->getOperation());
-        $this->assertEquals(5, count($files[1]->getChanges()[0]->getLines()));
+        $this->assertCount(5, $files[1]->getChanges()[0]->getLines());
     }
 }

--- a/tests/git/Command/Diff/CompareTest.php
+++ b/tests/git/Command/Diff/CompareTest.php
@@ -10,6 +10,8 @@
 
 namespace SebastianFeldmann\Git\Command\Diff;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Class CompareTest
  *
@@ -18,7 +20,7 @@ namespace SebastianFeldmann\Git\Command\Diff;
  * @link    https://github.com/sebastianfeldmann/git
  * @since   Class available since Release 1.2.0
  */
-class CompareTest extends \PHPUnit\Framework\TestCase
+class CompareTest extends TestCase
 {
     /**
      * Tests Compare::revision

--- a/tests/git/Command/DiffIndex/GetStagedFiles/FilterByStatusTest.php
+++ b/tests/git/Command/DiffIndex/GetStagedFiles/FilterByStatusTest.php
@@ -9,6 +9,8 @@
  */
 namespace SebastianFeldmann\Git\Command\DiffIndex\GetStagedFiles;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Class FilterByStatusTest
  *
@@ -17,7 +19,7 @@ namespace SebastianFeldmann\Git\Command\DiffIndex\GetStagedFiles;
  * @link    https://github.com/sebastianfeldmann/git
  * @since   Class available since Release 0.9.0
  */
-class FilterByStatusTest extends \PHPUnit\Framework\TestCase
+class FilterByStatusTest extends TestCase
 {
     /**
      * Tests FilterByStatus::format
@@ -36,7 +38,7 @@ M	tests/git/Command/Log/LogTest.php';
         $formatter = new FilterByStatus(['A', 'M']);
         $formatted = $formatter->format($output);
 
-        $this->assertEquals(6, count($formatted));
+        $this->assertCount(6, $formatted);
     }
 
     /**

--- a/tests/git/Command/DiffIndex/GetStagedFilesTest.php
+++ b/tests/git/Command/DiffIndex/GetStagedFilesTest.php
@@ -9,6 +9,8 @@
  */
 namespace SebastianFeldmann\Git\Command\DiffIndex;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Class GetStagedFilesTest
  *
@@ -17,7 +19,7 @@ namespace SebastianFeldmann\Git\Command\DiffIndex;
  * @link    https://github.com/sebastianfeldmann/git
  * @since   Class available since Release 0.9.0
  */
-class GetStagedFilesTest extends \PHPUnit\Framework\TestCase
+class GetStagedFilesTest extends TestCase
 {
     /**
      * Tests GetStagedFiles::getGitCommand

--- a/tests/git/Command/Log/ChangedFilesTest.php
+++ b/tests/git/Command/Log/ChangedFilesTest.php
@@ -9,6 +9,8 @@
  */
 namespace SebastianFeldmann\Git\Command\Log;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Class ChangedFilesTest
  *
@@ -17,7 +19,7 @@ namespace SebastianFeldmann\Git\Command\Log;
  * @link    https://github.com/sebastianfeldmann/git
  * @since   Class available since Release 0.9.0
  */
-class ChangedFilesTest extends \PHPUnit\Framework\TestCase
+class ChangedFilesTest extends TestCase
 {
     /**
      * Tests Commits::getCommand

--- a/tests/git/Command/Log/CommitsSince/JsonizedTest.php
+++ b/tests/git/Command/Log/CommitsSince/JsonizedTest.php
@@ -9,6 +9,9 @@
  */
 namespace SebastianFeldmann\Git\Command\Log\Commits;
 
+use SebastianFeldmann\Git\Log\Commit;
+use PHPUnit\Framework\TestCase;
+
 /**
  * Class JsonizedTest
  *
@@ -17,7 +20,7 @@ namespace SebastianFeldmann\Git\Command\Log\Commits;
  * @link    https://github.com/sebastianfeldmann/git
  * @since   Class available since Release 0.9.0
  */
-class JsonizedTest extends \PHPUnit\Framework\TestCase
+class JsonizedTest extends TestCase
 {
     public function testFormat()
     {
@@ -27,9 +30,9 @@ class JsonizedTest extends \PHPUnit\Framework\TestCase
            '"description": "Fix case in path", "date": "2017-01-16 02:16:13 +0100", "author": "Sebastian Feldmann"}',
         ]);
 
-        $this->assertEquals(1, count($result));
+        $this->assertCount(1, $result);
         $this->assertTrue($result[0]->hasNames());
-        $this->assertTrue(is_a($result[0], '\\SebastianFeldmann\\Git\\Log\\Commit'));
+        $this->assertTrue(is_a($result[0], Commit::class));
         $this->assertEquals('a9d9ac5', $result[0]->getHash());
         $this->assertEquals('Sebastian Feldmann', $result[0]->getAuthor());
     }

--- a/tests/git/Command/Log/CommitsTest.php
+++ b/tests/git/Command/Log/CommitsTest.php
@@ -9,6 +9,8 @@
  */
 namespace SebastianFeldmann\Git\Command\Log;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Class CommitsTest
  *
@@ -17,7 +19,7 @@ namespace SebastianFeldmann\Git\Command\Log;
  * @link    https://github.com/sebastianfeldmann/git
  * @since   Class available since Release 0.9.0
  */
-class CommitsTest extends \PHPUnit\Framework\TestCase
+class CommitsTest extends TestCase
 {
     /**
      * Tests Commits::getCommand

--- a/tests/git/Command/Log/LogTest.php
+++ b/tests/git/Command/Log/LogTest.php
@@ -9,6 +9,8 @@
  */
 namespace SebastianFeldmann\Git\Command\Log;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Class LogTest
  *
@@ -17,7 +19,7 @@ namespace SebastianFeldmann\Git\Command\Log;
  * @link    https://github.com/sebastianfeldmann/git
  * @since   Class available since Release 0.9.0
  */
-class LogTest extends \PHPUnit\Framework\TestCase
+class LogTest extends TestCase
 {
     /**
      * Tests Commits::withMerges

--- a/tests/git/Command/RefParse/GetCommitHashTest.php
+++ b/tests/git/Command/RefParse/GetCommitHashTest.php
@@ -9,6 +9,8 @@
  */
 namespace SebastianFeldmann\Git\Command\RevParse;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Class GetCommitHashTest
  *
@@ -17,7 +19,7 @@ namespace SebastianFeldmann\Git\Command\RevParse;
  * @link    https://github.com/sebastianfeldmann/git
  * @since   Class available since Release 0.9.0
  */
-class GetCommitHashTest extends \PHPUnit\Framework\TestCase
+class GetCommitHashTest extends TestCase
 {
     /**
      * Tests GetCommitHash::getGitCommand

--- a/tests/git/CommitMessageTest.php
+++ b/tests/git/CommitMessageTest.php
@@ -9,6 +9,8 @@
  */
 namespace SebastianFeldmann\Git;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Class CommitMessageTest
  *
@@ -17,7 +19,7 @@ namespace SebastianFeldmann\Git;
  * @link    https://github.com/sebastianfeldmann/git
  * @since   Class available since Release 0.9.0
  */
-class CommitMessageTest extends \PHPUnit\Framework\TestCase
+class CommitMessageTest extends TestCase
 {
     /**
      * Tests CommitMessage::isEmpty
@@ -25,6 +27,7 @@ class CommitMessageTest extends \PHPUnit\Framework\TestCase
     public function testIsEmpty()
     {
         $msg = new CommitMessage('');
+
         $this->assertTrue($msg->isEmpty());
     }
 
@@ -34,6 +37,7 @@ class CommitMessageTest extends \PHPUnit\Framework\TestCase
     public function testIsEmptyDoesNotIncludeComments()
     {
         $msg = new CommitMessage('# Testing', '#');
+
         $this->assertTrue($msg->isEmpty());
     }
 
@@ -44,6 +48,7 @@ class CommitMessageTest extends \PHPUnit\Framework\TestCase
     {
         $content = 'Foo' . PHP_EOL . 'Bar' . PHP_EOL . 'Baz';
         $msg = new CommitMessage($content);
+
         $this->assertEquals($content, $msg->getContent());
     }
 
@@ -55,6 +60,7 @@ class CommitMessageTest extends \PHPUnit\Framework\TestCase
     {
         $content = 'Foo' . PHP_EOL . '# Bar' . PHP_EOL . 'Baz';
         $msg = new CommitMessage($content, '#');
+
         $this->assertEquals('Foo' . PHP_EOL . 'Baz', $msg->getContent());
     }
 
@@ -65,6 +71,7 @@ class CommitMessageTest extends \PHPUnit\Framework\TestCase
     {
         $content = 'Foo' . PHP_EOL . '# Bar' . PHP_EOL . 'Baz';
         $msg = new CommitMessage($content,'#');
+
         $this->assertEquals($content, $msg->getRawContent());
     }
 
@@ -75,8 +82,9 @@ class CommitMessageTest extends \PHPUnit\Framework\TestCase
     {
         $msg   = new CommitMessage('Foo' . PHP_EOL . 'Bar' . PHP_EOL . 'Baz');
         $lines = $msg->getLines();
-        $this->assertTrue(is_array($lines));
-        $this->assertEquals(3, count($lines));
+
+        $this->assertInternalType('array', $lines);
+        $this->assertCount(3, $lines);
     }
 
     /**
@@ -86,8 +94,9 @@ class CommitMessageTest extends \PHPUnit\Framework\TestCase
     {
         $msg   = new CommitMessage('Foo' . PHP_EOL . '# Bar' . PHP_EOL . 'Baz', '#');
         $lines = $msg->getLines();
-        $this->assertTrue(is_array($lines));
-        $this->assertEquals(3, count($lines));
+
+        $this->assertInternalType('array', $lines);
+        $this->assertCount(3, $lines);
     }
 
     /**
@@ -96,6 +105,7 @@ class CommitMessageTest extends \PHPUnit\Framework\TestCase
     public function testLineCodeOnEmptyMessage()
     {
         $msg = new CommitMessage('');
+
         $this->assertEquals(0, $msg->getLineCount());
     }
 
@@ -105,6 +115,7 @@ class CommitMessageTest extends \PHPUnit\Framework\TestCase
     public function testLineCount()
     {
         $msg = new CommitMessage('Foo' . PHP_EOL . 'Bar' . PHP_EOL . 'Baz');
+
         $this->assertEquals(3, $msg->getLineCount());
     }
     /**
@@ -113,6 +124,7 @@ class CommitMessageTest extends \PHPUnit\Framework\TestCase
     public function testLineCountIncludesComments()
     {
         $msg = new CommitMessage('Foo' . PHP_EOL . '# Bar' . PHP_EOL . 'Baz', '#');
+
         $this->assertEquals(3, $msg->getLineCount());
     }
 
@@ -122,6 +134,7 @@ class CommitMessageTest extends \PHPUnit\Framework\TestCase
     public function testGetSubject()
     {
         $msg = new CommitMessage('Foo' . PHP_EOL . 'Bar' . PHP_EOL . 'Baz');
+
         $this->assertEquals('Foo', $msg->getSubject());
     }
 
@@ -131,6 +144,7 @@ class CommitMessageTest extends \PHPUnit\Framework\TestCase
     public function testGetSubjectDoesNotIncludeComments()
     {
         $msg = new CommitMessage('# Foo' . PHP_EOL . 'Bar' . PHP_EOL . 'Baz', '#');
+
         $this->assertEquals('Bar', $msg->getSubject());
     }
 
@@ -140,6 +154,7 @@ class CommitMessageTest extends \PHPUnit\Framework\TestCase
     public function testGetBody()
     {
         $msg = new CommitMessage('Foo' . PHP_EOL . PHP_EOL . 'Bar' . PHP_EOL . 'Baz');
+
         $this->assertEquals('Bar' . PHP_EOL . 'Baz', $msg->getBody());
     }
 
@@ -149,6 +164,7 @@ class CommitMessageTest extends \PHPUnit\Framework\TestCase
     public function testGetBodyDoesNotIncludeComments()
     {
         $msg = new CommitMessage('Foo' . PHP_EOL . PHP_EOL . '# Bar' . PHP_EOL . 'Baz', '#');
+
         $this->assertEquals('Baz', $msg->getBody());
     }
 
@@ -159,7 +175,8 @@ class CommitMessageTest extends \PHPUnit\Framework\TestCase
     {
         $msg   = new CommitMessage('Foo' . PHP_EOL . PHP_EOL . 'Bar' . PHP_EOL . 'Baz');
         $lines = $msg->getBodyLines();
-        $this->assertEquals(2, count($lines));
+
+        $this->assertCount(2, $lines);
         $this->assertEquals('Bar', $lines[0]);
         $this->assertEquals('Baz', $lines[1]);
     }
@@ -170,7 +187,8 @@ class CommitMessageTest extends \PHPUnit\Framework\TestCase
     {
         $msg   = new CommitMessage('Foo' . PHP_EOL . PHP_EOL . '# Bar' . PHP_EOL . 'Baz', '#');
         $lines = $msg->getBodyLines();
-        $this->assertEquals(1, count($lines));
+
+        $this->assertCount(1, $lines);
         $this->assertEquals('Baz', $lines[0]);
     }
 
@@ -180,6 +198,7 @@ class CommitMessageTest extends \PHPUnit\Framework\TestCase
     public function testGetLine()
     {
         $msg = new CommitMessage('Foo' . PHP_EOL . 'Bar' . PHP_EOL . 'Baz');
+
         $this->assertEquals('Foo', $msg->getLine(0));
         $this->assertEquals('Bar', $msg->getLine(1));
         $this->assertEquals('Baz', $msg->getLine(2));
@@ -191,6 +210,7 @@ class CommitMessageTest extends \PHPUnit\Framework\TestCase
     public function testGetLineIncludesCommentLines()
     {
         $msg = new CommitMessage('Foo' . PHP_EOL . '# Bar' . PHP_EOL . 'Baz', '#');
+
         $this->assertEquals('Foo', $msg->getLine(0));
         $this->assertEquals('# Bar', $msg->getLine(1));
         $this->assertEquals('Baz', $msg->getLine(2));
@@ -212,6 +232,7 @@ class CommitMessageTest extends \PHPUnit\Framework\TestCase
     public function testCreateFromFileOk()
     {
         $message = CommitMessage::createFromFile(SF_GIT_PATH_FILES . '/git/message/valid.txt');
+
         $this->assertEquals('This is a valid dummy commit Message', $message->getSubject());
     }
 

--- a/tests/git/Diff/ChangeTest.php
+++ b/tests/git/Diff/ChangeTest.php
@@ -9,6 +9,8 @@
  */
 namespace SebastianFeldmann\Git\Diff;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Class ChangeTest
  *
@@ -17,7 +19,7 @@ namespace SebastianFeldmann\Git\Diff;
  * @link    https://github.com/sebastianfeldmann/git
  * @since   Class available since Release 1.2.0
  */
-class ChangeTest extends \PHPUnit\Framework\TestCase
+class ChangeTest extends TestCase
 {
     /**
      * Tests Change::__construct
@@ -39,7 +41,7 @@ class ChangeTest extends \PHPUnit\Framework\TestCase
         $change = new Change('-0,5 +0,10', 'foo bar');
         $change->addLine(new Line(Line::ADDED, 'fiz baz'));
 
-        $this->assertEquals(1, count($change->getLines()));
+        $this->assertCount(1, $change->getLines());
     }
 
     /**

--- a/tests/git/Diff/FileTest.php
+++ b/tests/git/Diff/FileTest.php
@@ -9,6 +9,8 @@
  */
 namespace SebastianFeldmann\Git\Diff;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Class FileTest
  *
@@ -17,7 +19,7 @@ namespace SebastianFeldmann\Git\Diff;
  * @link    https://github.com/sebastianfeldmann/git
  * @since   Class available since Release 1.1.1
  */
-class FileTest extends \PHPUnit\Framework\TestCase
+class FileTest extends TestCase
 {
     /**
      * Tests File::getName
@@ -25,6 +27,7 @@ class FileTest extends \PHPUnit\Framework\TestCase
     public function testGetName()
     {
         $file = new File('foo', File::OP_MODIFIED);
+
         $this->assertEquals('foo', $file->getName());
     }
 
@@ -34,6 +37,7 @@ class FileTest extends \PHPUnit\Framework\TestCase
     public function testGetOperation()
     {
         $file = new File('foo', File::OP_MODIFIED);
+
         $this->assertEquals(File::OP_MODIFIED, $file->getOperation());
     }
 
@@ -43,6 +47,7 @@ class FileTest extends \PHPUnit\Framework\TestCase
     public function testChangesEmptyOnInit()
     {
         $file = new File('foo', File::OP_MODIFIED);
+
         $this->assertEquals([], $file->getChanges());
     }
 
@@ -57,7 +62,7 @@ class FileTest extends \PHPUnit\Framework\TestCase
         $changes = $file->getChanges();
         $change  = $changes[0];
 
-        $this->assertEquals(1, count($changes));
+        $this->assertCount(1, $changes);
         $this->assertEquals('foo', $change->getHeader());
     }
 
@@ -75,9 +80,9 @@ class FileTest extends \PHPUnit\Framework\TestCase
         $changes = $file->getChanges();
         $change  = $changes[0];
 
-        $this->assertEquals(1, count($changes));
+        $this->assertCount(1, $changes);
         $this->assertEquals('bar', $change->getHeader());
-        $this->assertEquals(1, count($change->getLines()));
+        $this->assertCount(1, $change->getLines());
         $this->assertEquals(Line::ADDED, $change->getLines()[0]->getOperation());
         $this->assertEquals('baz', $change->getLines()[0]->getContent());
     }

--- a/tests/git/Diff/LineTest.php
+++ b/tests/git/Diff/LineTest.php
@@ -9,6 +9,8 @@
  */
 namespace SebastianFeldmann\Git\Diff;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Class LineTest
  *
@@ -17,7 +19,7 @@ namespace SebastianFeldmann\Git\Diff;
  * @link    https://github.com/sebastianfeldmann/git
  * @since   Class available since Release 1.2.0
  */
-class LineTest extends \PHPUnit\Framework\TestCase
+class LineTest extends TestCase
 {
     /**
      * Tests Line::__construct

--- a/tests/git/Log/CommitTest.php
+++ b/tests/git/Log/CommitTest.php
@@ -9,6 +9,8 @@
  */
 namespace SebastianFeldmann\Git\Log;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Class CommitTest
  *
@@ -17,7 +19,7 @@ namespace SebastianFeldmann\Git\Log;
  * @link    https://github.com/sebastianfeldmann/git
  * @since   Class available since Release 1.2.0
  */
-class CommitTest extends \PHPUnit\Framework\TestCase
+class CommitTest extends TestCase
 {
     /**
      * Tests Commit::__construct

--- a/tests/git/Operator/ConfigTest.php
+++ b/tests/git/Operator/ConfigTest.php
@@ -39,7 +39,7 @@ class ConfigTest extends OperatorTest
         $config = new Config($runner, $repo);
         $hasKey = $config->has('core.commentchar');
 
-        $this->assertEquals(true, $hasKey);
+        $this->assertTrue($hasKey);
     }
 
     /**
@@ -63,7 +63,7 @@ class ConfigTest extends OperatorTest
         $config = new Config($runner, $repo);
         $hasKey = $config->has('core.commentchar');
 
-        $this->assertEquals(false, $hasKey);
+        $this->assertFalse($hasKey);
     }
 
     /**

--- a/tests/git/Operator/DiffTest.php
+++ b/tests/git/Operator/DiffTest.php
@@ -53,7 +53,7 @@ class DiffTest extends OperatorTest
         $diff  = new Diff($runner, $repo);
         $files = $diff->compare('1.0.0', '1.1.0');
 
-        $this->assertTrue(is_array($files));
-        $this->assertEquals(2, count($files));
+        $this->assertInternaltype('array', $files);
+        $this->assertCount(2, $files);
     }
 }

--- a/tests/git/Operator/IndexTest.php
+++ b/tests/git/Operator/IndexTest.php
@@ -64,8 +64,8 @@ class IndexTest extends OperatorTest
         $operator = new Index($runner, $repo);
         $files    = $operator->getStagedFiles();
 
-        $this->assertTrue(is_array($files));
-        $this->assertEquals(4, count($files));
+        $this->assertInternalType('array', $files);
+        $this->assertCount(4, $files);
     }
 
     /**
@@ -91,8 +91,8 @@ class IndexTest extends OperatorTest
         $operator = new Index($runner, $repo);
         $files    = $operator->getStagedFilesOfType('php');
 
-        $this->assertTrue(is_array($files));
-        $this->assertEquals(2, count($files));
+        $this->assertInternalType('array', $files);
+        $this->assertCount(2, $files);
     }
 
     /**

--- a/tests/git/Operator/LogTest.php
+++ b/tests/git/Operator/LogTest.php
@@ -41,7 +41,7 @@ class LogTest extends OperatorTest
         $log   = new Log($runner, $repo);
         $files = $log->getChangedFilesSince('b1ef1997291');
 
-        $this->assertEquals(1, count($files));
+        $this->assertCount(1, $files);
         $this->assertEquals('tests/bootstrap.php', $files[0]);
     }
 
@@ -79,7 +79,7 @@ class LogTest extends OperatorTest
         $log     = new Log($runner, $repo);
         $commits = $log->getCommitsSince('b1ef1997291');
 
-        $this->assertTrue(is_array($commits));
+        $this->assertInternalType('array', $commits);
         $this->assertEquals('Sebastian Feldmann', $commits[0]->getAuthor());
     }
 
@@ -117,7 +117,7 @@ class LogTest extends OperatorTest
         $log     = new Log($runner, $repo);
         $commits = $log->getCommitsBetween('b1ef1997291', 'a1ef1577fe1');
 
-        $this->assertTrue(is_array($commits));
+        $this->assertInternalType('array', $commits);
         $this->assertEquals('Sebastian Feldmann', $commits[0]->getAuthor());
     }
 }

--- a/tests/git/Operator/OperatorTest.php
+++ b/tests/git/Operator/OperatorTest.php
@@ -9,6 +9,10 @@
  */
 namespace SebastianFeldmann\Git\Operator;
 
+use SebastianFeldmann\Cli\Command\Runner;
+use SebastianFeldmann\Git\Repository;
+use PHPUnit\Framework\TestCase;
+
 /**
  * Class OperatorTest
  *
@@ -17,7 +21,7 @@ namespace SebastianFeldmann\Git\Operator;
  * @link    https://github.com/sebastianfeldmann/git
  * @since   Class available since Release 0.9.0
  */
-abstract class OperatorTest extends \PHPUnit\Framework\TestCase
+abstract class OperatorTest extends TestCase
 {
     /**
      * Return repository mock.
@@ -26,7 +30,7 @@ abstract class OperatorTest extends \PHPUnit\Framework\TestCase
      */
     protected function getRepoMock()
     {
-        $repo = $this->getMockBuilder('\\SebastianFeldmann\\Git\\Repository')
+        $repo = $this->getMockBuilder(Repository::class)
                      ->disableOriginalConstructor()
                      ->getMock();
 
@@ -40,7 +44,7 @@ abstract class OperatorTest extends \PHPUnit\Framework\TestCase
      */
     protected function getRunnerMock()
     {
-        $runner = $this->getMockBuilder('\\SebastianFeldmann\\Cli\\Command\\Runner')
+        $runner = $this->getMockBuilder(Runner::class)
                        ->disableOriginalConstructor()
                        ->getMock();
 

--- a/tests/git/RepositoryTest.php
+++ b/tests/git/RepositoryTest.php
@@ -9,6 +9,12 @@
  */
 namespace SebastianFeldmann\Git;
 
+use SebastianFeldmann\Git\Operator\Index;
+use SebastianFeldmann\Git\Operator\Info;
+use SebastianFeldmann\Git\Operator\Log;
+use SebastianFeldmann\Git\Operator\Config;
+use PHPUnit\Framework\TestCase;
+
 /**
  * Class RepositoryTest
  *
@@ -17,7 +23,7 @@ namespace SebastianFeldmann\Git;
  * @link    https://github.com/sebastianfeldmann/git
  * @since   Class available since Release 0.9.0
  */
-class RepositoryTest extends \PHPUnit\Framework\TestCase
+class RepositoryTest extends TestCase
 {
     /**
      * @var \SebastianFeldmann\Git\DummyRepo
@@ -49,7 +55,8 @@ class RepositoryTest extends \PHPUnit\Framework\TestCase
     public function testInvalidRepository()
     {
         $repository = new Repository('invalidGitRepo');
-        $this->assertFalse(is_a($repository, '\\SebastianFeldmann\\Git\\Repository'));
+
+        $this->assertFalse(is_a($repository, Repository::class));
     }
 
     /**
@@ -70,6 +77,7 @@ class RepositoryTest extends \PHPUnit\Framework\TestCase
     public function testGetHooksDir()
     {
         $repository = new Repository($this->repo->getPath());
+
         $this->assertEquals($this->repo->getPath() . '/.git/hooks', $repository->getHooksDir());
         $this->assertEquals($this->repo->getPath(), $repository->getRoot());
     }
@@ -104,6 +112,7 @@ class RepositoryTest extends \PHPUnit\Framework\TestCase
     public function testIsMergingNegative()
     {
         $repository = new Repository($this->repo->getPath());
+
         $this->assertFalse($repository->isMerging());
     }
 
@@ -114,6 +123,7 @@ class RepositoryTest extends \PHPUnit\Framework\TestCase
     {
         $this->repo->merge();
         $repository = new Repository($this->repo->getPath());
+
         $this->assertTrue($repository->isMerging());
     }
 
@@ -125,7 +135,7 @@ class RepositoryTest extends \PHPUnit\Framework\TestCase
         $repository = new Repository($this->repo->getPath());
         $operator   = $repository->getIndexOperator();
 
-        $this->assertTrue(is_a($operator, '\\SebastianFeldmann\\Git\\Operator\\Index'));
+        $this->assertTrue(is_a($operator, Index::class));
     }
 
     /**
@@ -136,7 +146,7 @@ class RepositoryTest extends \PHPUnit\Framework\TestCase
         $repository = new Repository($this->repo->getPath());
         $operator   = $repository->getInfoOperator();
 
-        $this->assertTrue(is_a($operator, '\\SebastianFeldmann\\Git\\Operator\\Info'));
+        $this->assertTrue(is_a($operator, Info::class));
     }
 
     /**
@@ -147,7 +157,7 @@ class RepositoryTest extends \PHPUnit\Framework\TestCase
         $repository = new Repository($this->repo->getPath());
         $operator   = $repository->getLogOperator();
 
-        $this->assertTrue(is_a($operator, '\\SebastianFeldmann\\Git\\Operator\\Log'));
+        $this->assertTrue(is_a($operator, Log::class));
     }
 
     /**
@@ -158,6 +168,6 @@ class RepositoryTest extends \PHPUnit\Framework\TestCase
         $repository = new Repository($this->repo->getPath());
         $operator   = $repository->getConfigOperator();
 
-        $this->assertTrue(is_a($operator, '\\SebastianFeldmann\\Git\\Operator\\Config'));
+        $this->assertTrue(is_a($operator, Config::class));
     }
 }


### PR DESCRIPTION
# Changed log
- Using correct assertions for the tests.
- Add the PHPUnit version inside `require-dev` block in `composer.json`.
- Add the `autoload-dev` block to load test classes automatically.
- `use PHPUnit\Framework\TestCase` because of consistency.