### PR TITLE
InfoOperator can return current commit hash

### DIFF
--- a/src/Operator/Info.php
+++ b/src/Operator/Info.php
@@ -10,6 +10,7 @@
 namespace SebastianFeldmann\Git\Operator;
 
 use SebastianFeldmann\Git\Command\Describe\GetCurrentTag;
+use SebastianFeldmann\Git\Command\RevParse\GetCommitHash;
 
 /**
  * Class Info
@@ -29,6 +30,19 @@ class Info extends Base
     public function getCurrentTag() : string
     {
         $cmd    = new GetCurrentTag($this->repo->getRoot());
+        $result = $this->runner->run($cmd);
+
+        return trim($result->getStdOut());
+    }
+
+    /**
+     * Returns the the hash of the current commit
+     *
+     * @return string
+     */
+    public function getCurrentCommitHash() : string
+    {
+        $cmd    = new GetCommitHash($this->repo->getRoot());
         $result = $this->runner->run($cmd);
 
         return trim($result->getStdOut());

--- a/tests/git/Operator/InfoTest.php
+++ b/tests/git/Operator/InfoTest.php
@@ -64,4 +64,46 @@ class InfoTest extends OperatorTest
         // should never get asserted and fail in error case
         $this->assertEquals('1.0.0', $tag);
     }
+
+    /**
+     * Tests Info::getCurrentCommitHash
+     */
+    public function testGetCurrentCommitHashSuccess()
+    {
+        $repo   = $this->getRepoMock();
+        $runner = $this->getRunnerMock();
+        $cmd    = new CommandResult('rev-parse --verify 6b1cb23', 0, '6b1cb23' . PHP_EOL);
+        $result = new RunnerResult($cmd);
+
+        $repo->method('getRoot')->willReturn(realpath(__FILE__ . '/../../..'));
+
+        $runner->expects($this->once())
+            ->method('run')
+            ->willReturn($result);
+
+        $operator = new Info($runner, $repo);
+        $tag      = $operator->getCurrentCommitHash();
+
+        $this->assertEquals('6b1cb23', $tag);
+    }
+
+    /**
+     * Tests Info::getCurrentCommitHash
+     *
+     * @expectedException \RuntimeException
+     */
+    public function testGetCurrentCommitHashFail()
+    {
+        $repo   = $this->getRepoMock();
+        $runner = $this->getRunnerMock();
+
+        $repo->method('getRoot')->willReturn(realpath(__FILE__ . '/../../..'));
+        $runner->method('run')->will($this->throwException(new RuntimeException()));
+
+        $operator = new Info($runner, $repo);
+        $tag      = $operator->getCurrentCommitHash();
+
+        // should never get asserted and fail in error case
+        $this->assertEquals('6b1cb23', $tag);
+    }
 }


### PR DESCRIPTION
Add getCurrentCommitHash() method to the InfoOperator to be able to query the latest commit hash easily.