### PR TITLE
Fix deprecation warning when using with PHP 7.4

### DIFF
--- a/src/CommitMessage.php
+++ b/src/CommitMessage.php
@@ -245,7 +245,7 @@ class CommitMessage
 
         foreach ($rawLines as $line) {
             // if we handle a comment line
-            if (isset($line{0}) && $line{0} === $commentCharacter) {
+            if (isset($line[0]) && $line[0] === $commentCharacter) {
                 // check if we should ignore all following lines
                 if (strpos($line, '------------------------ >8 ------------------------') !== false) {
                     break;


### PR DESCRIPTION
In PHP 7.4 the "[array and string offset access syntax using curly braces is deprecated](https://www.php.net/manual/en/migration74.deprecated.php#migration74.deprecated.core.array-string-access-curly-brace)".
The fix is simple: change {} to [].