### PR TITLE
Improve test stuffs

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,6 +1,6 @@
 name: "CI-Build"
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:
@@ -17,7 +17,7 @@ jobs:
       uses: shivammathur/setup-php@master
       with:
         php-version: ${{ matrix.php-versions }}
-        extensions: mbstring, xdebug
+        extensions: xdebug
 
     - name: Validate composer.json and composer.lock
       run: composer validate

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     }
   },
   "require": {
-    "php": "^7.1",
+    "php": "^7.2",
     "ext-json": "*",
     "ext-xml": "*",
     "sebastianfeldmann/cli": "^3.0"

--- a/tests/git/RepositoryTest.php
+++ b/tests/git/RepositoryTest.php
@@ -36,7 +36,7 @@ class RepositoryTest extends TestCase
     /**
      * Setup dummy repo.
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->repo = new DummyRepo();
         $this->repo->setup();
@@ -45,7 +45,7 @@ class RepositoryTest extends TestCase
     /**
      * Cleanup dummy repo.
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         $this->repo->cleanup();
     }


### PR DESCRIPTION
# Changed log
- Add `pull_request` trigger on GitHub Action for oncoming pull requests.
- Remove `mbstring` extension on `integration.yml` file because it's not necessary.
- It seems that this package requires `php-7.2` version at least because the `PHPUnit` version is `8.x` at least.
- According to PHPUnit fixture reference, the `setUp` and `tearDown` methods should be `protected`.