### PR TITLE
Implement support for submodule repositories

### DIFF
--- a/src/Repository.php
+++ b/src/Repository.php
@@ -71,6 +71,14 @@ class Repository
         $this->root      = $path;
         $this->dotGitDir = $this->root . '/.git';
         $this->runner    = null == $runner ? new Runner\Simple() : $runner;
+
+        if (!is_dir($this->dotGitDir) && is_file($this->dotGitDir)) {
+            // This is a submodule - hooks are stored in the parents' .git/modules directory
+            $dotGitContents = file_get_contents($root . '/.git');
+            if (preg_match('/^gitdir:\s*(.+)$/m', $dotGitContents, $matches)) {
+                $this->dotGitDir = $root . '/' . $matches[1];
+            }
+        }
     }
 
     /**
@@ -231,6 +239,6 @@ class Repository
      */
     public static function isGitRepository(string $root): bool
     {
-        return is_dir($root . '/.git');
+        return is_dir($root . '/.git') || is_file($root . '/.git');
     }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -12,4 +12,5 @@
 require __DIR__ . '/../vendor/autoload.php';
 require __DIR__ . '/constants.php';
 require __DIR__ . '/git/DummyRepo.php';
+require __DIR__ . '/git/DummySubmoduleRepo.php';
 require __DIR__ . '/git/Operator/OperatorTest.php';

--- a/tests/git/DummyRepo.php
+++ b/tests/git/DummyRepo.php
@@ -24,12 +24,12 @@ class DummyRepo
     /**
      * @var string
      */
-    private $path;
+    protected $path;
 
     /**
      * @var string
      */
-    private $gitDir;
+    protected $gitDir;
 
     /**
      * DummyRepo constructor

--- a/tests/git/DummySubmoduleRepo.php
+++ b/tests/git/DummySubmoduleRepo.php
@@ -1,0 +1,84 @@
+<?php
+
+/**
+ * This file is part of SebastianFeldmann\Git.
+ *
+ * (c) Sebastian Feldmann <sf@sebastian-feldmann.info>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace SebastianFeldmann\Git;
+
+/**
+ * Class DummySubmoduleRepo
+ *
+ * If you're working within a submodule, there is no .git directory.
+ * Instead their hooks are stored in the parents' repository .git/modules/<name>/hooks directory.
+ *
+ * Since submodules might be nested, the parent repository is not always the parent directory.
+ *
+ * @package SebastianFeldmann\Git
+ */
+class DummySubmoduleRepo extends DummyRepo
+{
+    /**
+     * @var string
+     */
+    private $relativeGitDir;
+
+    /**
+     * @var int
+     */
+    private $level;
+
+    public function __construct(string $name = '', int $level = 1)
+    {
+        $this->level = $level;
+
+        $parents = '';
+        for ($i = 0; $i < $level; $i++) {
+            if (!empty($parents)) {
+                $parents .= DIRECTORY_SEPARATOR;
+            }
+            $parents .= md5(mt_rand(0, 9999));
+        }
+
+        $name       = empty($name) ? md5(mt_rand(0, 9999)) : $name;
+        $this->path = realpath(sys_get_temp_dir()) . DIRECTORY_SEPARATOR . $parents . DIRECTORY_SEPARATOR . $name;
+
+        $this->relativeGitDir = str_repeat('..' . DIRECTORY_SEPARATOR, $level)
+            . '.git' . DIRECTORY_SEPARATOR . 'modules' . DIRECTORY_SEPARATOR . $name;
+        $this->gitDir         = $this->path . DIRECTORY_SEPARATOR . $this->relativeGitDir;
+    }
+
+    public function setup(): void
+    {
+        parent::setup();
+
+        mkdir($this->path, 0777, true);
+        file_put_contents($this->path . DIRECTORY_SEPARATOR . '.git', 'gitdir: ' . $this->relativeGitDir);
+    }
+
+    /**
+     * Level getter
+     *
+     * @return int
+     */
+    public function getLevel(): int
+    {
+        return $this->level;
+    }
+
+    /**
+     * Cleanup all dummy files
+     *
+     * @return void
+     */
+    public function cleanup(): void
+    {
+        $parent = dirname($this->path, $this->level);
+        system('rm -rf ' . escapeshellarg($parent));
+    }
+}


### PR DESCRIPTION
We struggle with CaptainHook not being able to run hooks in submodule directories. With support for submodules within this library, development within submodules will be the same as for a main repository. While you could checkout the submodule on its own and have those hooks enabled, often it is desired to change code within a submodule directory and being able to test changes this way together with the parents' repository code.

This pull request is similar to #13 and covers:
* when developing within a submodule, you got no .git directory, but a .git file
* the submodule's .git file references its .git folder within the parents' .git/modules directory
* use PHPUnit dataProvider to cover possible (nested) repository layouts