### PR TITLE
Implement remove command to remove files from the index

### DIFF
--- a/src/Command/Rm/RemoveFiles.php
+++ b/src/Command/Rm/RemoveFiles.php
@@ -1,0 +1,134 @@
+<?php
+
+/**
+ * This file is part of SebastianFeldmann\Git.
+ *
+ * (c) Sebastian Feldmann <sf@sebastian-feldmann.info>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace SebastianFeldmann\Git\Command\Rm;
+
+use SebastianFeldmann\Git\Command\Base;
+
+/**
+ * Class RemoveFiles
+ *
+ * @package SebastianFeldmann\Git
+ * @author  Sebastian Feldmann <sf@sebastian-feldmann.info>
+ * @link    https://github.com/sebastianfeldmann/git
+ * @since   Class available since Release 3.7.0
+ */
+class RemoveFiles extends Base
+{
+    /**
+     * Dry run.
+     *
+     * @var string
+     */
+    private $dryRun = '';
+
+    /**
+     * Cached.
+     *
+     * @var string
+     */
+    private $cached = '';
+
+    /**
+     * Recursive removal.
+     *
+     * @var string
+     */
+    private $recursive = '';
+
+    /**
+     * Files to remove.
+     *
+     * @var string[]
+     */
+    private $files = [];
+
+    /**
+     * Set dry run.
+     *
+     * @param  bool $bool
+     *
+     * @return \SebastianFeldmann\Git\Command\Rm\RemoveFiles
+     */
+    public function dryRun(bool $bool = true): RemoveFiles
+    {
+        $this->dryRun = $this->useOption('--dry-run', $bool);
+        return $this;
+    }
+
+    /**
+     * Unstage and remove paths only from the index.
+     *
+     * Working tree files, whether modified or not, will be left alone..
+     *
+     * @param  bool $bool
+     *
+     * @return \SebastianFeldmann\Git\Command\Rm\RemoveFiles
+     */
+    public function cached(bool $bool = true): RemoveFiles
+    {
+        $this->cached = $this->useOption('--cached', $bool);
+        return $this;
+    }
+
+    /**
+     * Allow recursive removal when a leading directory name is given.
+     *
+     * @param  bool $bool
+     *
+     * @return \SebastianFeldmann\Git\Command\Rm\RemoveFiles
+     */
+    public function recursive(bool $bool = true): RemoveFiles
+    {
+        $this->recursive = $this->useOption('-r', $bool);
+        return $this;
+    }
+
+    /**
+     * Files to remove.
+     *
+     * A leading directory name (e.g. `dir` to remove `dir/file1` and
+     * `dir/file2`) can be given to remove all files in the directory, and
+     * recursively all sub-directories, but this requires the `-r` option to be
+     * explicitly given.
+     *
+     * The command removes only the paths that are known to Git.
+     *
+     * File globbing matches across directory boundaries. Thus, given two
+     * directories `d` and `d2`, there is a difference between using
+     * `git rm 'd*'` and `git rm 'd/*'`, as the former will also remove all of
+     * directory `d2`.
+     *
+     * @param array $files
+     *
+     * @return \SebastianFeldmann\Git\Command\Rm\RemoveFiles
+     */
+    public function files(array $files): RemoveFiles
+    {
+        $this->files = $files;
+        return $this;
+    }
+
+    /**
+     * Return the command to execute.
+     *
+     * @return string
+     */
+    protected function getGitCommand(): string
+    {
+        return 'rm'
+            . $this->dryRun
+            . $this->cached
+            . $this->recursive
+            . ' -- '
+            . implode(' ', array_map('escapeshellarg', $this->files));
+    }
+}

--- a/src/Operator/Index.php
+++ b/src/Operator/Index.php
@@ -16,6 +16,7 @@ use SebastianFeldmann\Git\Command\Add\AddFiles;
 use SebastianFeldmann\Git\Command\DiffIndex\GetStagedFiles;
 use SebastianFeldmann\Git\Command\DiffIndex\GetStagedFiles\FilterByStatus;
 use SebastianFeldmann\Git\Command\RevParse\GetCommitHash;
+use SebastianFeldmann\Git\Command\Rm\RemoveFiles;
 
 /**
  * Index CommitMessage
@@ -162,6 +163,32 @@ class Index extends Base
     public function recordIntentToAddFiles(array $files): bool
     {
         $cmd = (new AddFiles($this->repo->getRoot()))->files($files)->intentToAdd();
+
+        $result = $this->runner->run($cmd);
+
+        return $result->isSuccessful();
+    }
+
+    /**
+     * Remove files from the working tree and from the index.
+     *
+     * @param array $files     The files to remove.
+     * @param bool $recursive  Allow recursive removal when a leading directory
+     *                         name is given
+     * @param bool $cachedOnly Unstage and remove paths only from the index.
+     *                         The working tree is untouched.
+     *
+     * @return bool
+     */
+    public function removeFiles(
+        array $files,
+        bool $recursive = false,
+        bool $cachedOnly = false
+    ): bool {
+        $cmd = (new RemoveFiles($this->repo->getRoot()))
+            ->files($files)
+            ->recursive($recursive)
+            ->cached($cachedOnly);
 
         $result = $this->runner->run($cmd);
 

--- a/tests/git/Command/Rm/RemoveFilesTest.php
+++ b/tests/git/Command/Rm/RemoveFilesTest.php
@@ -1,0 +1,81 @@
+<?php
+
+/**
+ * This file is part of SebastianFeldmann\Git.
+ *
+ * (c) Sebastian Feldmann <sf@sebastian-feldmann.info>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace SebastianFeldmann\Git\Command\Rm;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class RemoveFilesTest
+ *
+ * @package SebastianFeldmann\Git
+ * @author  Sebastian Feldmann <sf@sebastian-feldmann.info>
+ * @link    https://github.com/sebastianfeldmann/git
+ * @since   Class available since Release 3.7.0
+ */
+class RemoveFilesTest extends TestCase
+{
+    public function testDryRun(): void
+    {
+        $remove = new RemoveFiles();
+        $remove = $remove->dryRun();
+
+        $this->assertSame('git rm --dry-run -- ', $remove->getCommand());
+    }
+
+    public function testCached(): void
+    {
+        $remove = new RemoveFiles();
+        $remove = $remove->cached();
+
+        $this->assertSame('git rm --cached -- ', $remove->getCommand());
+    }
+
+    public function testRecursive(): void
+    {
+        $remove = new RemoveFiles();
+        $remove = $remove->recursive();
+
+        $this->assertSame('git rm -r -- ', $remove->getCommand());
+    }
+
+    public function testFiles(): void
+    {
+        $remove = new RemoveFiles();
+        $remove = $remove->files([
+            "foo/*",
+            "foo bar.txt",
+            "foo' 'bar.txt",
+            "føøBár.txt",
+        ]);
+
+        $this->assertSame(
+            "git rm -- 'foo/*' 'foo bar.txt' 'foo'\'' '\''bar.txt' 'føøBár.txt'",
+            $remove->getCommand()
+        );
+    }
+
+    public function testCombinedMethods(): void
+    {
+        $remove = new RemoveFiles();
+        $remove = $remove->dryRun()->recursive()->cached()->files([
+            "foo/*",
+            "foo bar.txt",
+            "foo' 'bar.txt",
+            "føøBár.txt",
+        ]);
+
+        $this->assertSame(
+            "git rm --dry-run --cached -r -- 'foo/*' 'foo bar.txt' 'foo'\'' '\''bar.txt' 'føøBár.txt'",
+            $remove->getCommand()
+        );
+    }
+}


### PR DESCRIPTION
This PR provides `git rm` functionality to remove files by marking them as "deleted" in the index.

## Example

```php
use SebastianFeldmann\Git;

$repo = new Git\Repository(__DIR__);

$repo->getIndexOperator()->removeFiles(['README.md']);

$deletedInIndex = array_filter(
    $repo->getStatusOperator()->getWorkingTreeStatus(),
    fn ($path): bool => $path->isDeletedFromIndex()
);

foreach ($deletedInIndex as $deletedFile) {
    echo $deletedFile->getPath() . PHP_EOL;
}
```