### PR TITLE
Implement command for generating patch of unstaged changes

### DIFF
--- a/src/Command/DiffIndex/GetUnstagedPatch.php
+++ b/src/Command/DiffIndex/GetUnstagedPatch.php
@@ -1,0 +1,74 @@
+<?php
+
+/**
+ * This file is part of SebastianFeldmann\Git.
+ *
+ * (c) Sebastian Feldmann <sf@sebastian-feldmann.info>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace SebastianFeldmann\Git\Command\DiffIndex;
+
+use SebastianFeldmann\Git\Command\Base;
+use SebastianFeldmann\Git\Command\Status\WorkingTreeStatus;
+
+/**
+ * Class GetUnstagedPatch
+ *
+ * @package SebastianFeldmann\Git
+ * @author  Sebastian Feldmann <sf@sebastian-feldmann.info>
+ * @link    https://github.com/sebastianfeldmann/git
+ * @since   Class available since Release 3.7.0
+ */
+class GetUnstagedPatch extends Base
+{
+    /**
+     * Tree object ID.
+     *
+     * @var string|null
+     */
+    private $treeId = null;
+
+    /**
+     * Return list of acceptable exit codes.
+     *
+     * @return array
+     */
+    public function getAcceptableExitCodes(): array
+    {
+        return [0, 1];
+    }
+
+    /**
+     * Set tree object ID.
+     *
+     * @param string|null $treeId
+     *
+     * @return \SebastianFeldmann\Git\Command\DiffIndex\GetUnstagedPatch
+     */
+    public function tree(?string $treeId): GetUnstagedPatch
+    {
+        $this->treeId = $treeId;
+        return $this;
+    }
+
+    /**
+     * Return the command to execute.
+     *
+     * @return string
+     * @throws \RuntimeException
+     */
+    protected function getGitCommand(): string
+    {
+        return 'diff-index'
+            . ' --ignore-submodules'
+            . ' --binary'
+            . ' --exit-code'
+            . ' --no-color'
+            . ' --no-ext-diff'
+            . ($this->treeId ? ' ' . escapeshellarg($this->treeId) : '')
+            . ' -- ';
+    }
+}

--- a/src/Command/WriteTree/CreateTreeObject.php
+++ b/src/Command/WriteTree/CreateTreeObject.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * This file is part of SebastianFeldmann\Git.
+ *
+ * (c) Sebastian Feldmann <sf@sebastian-feldmann.info>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace SebastianFeldmann\Git\Command\WriteTree;
+
+use SebastianFeldmann\Git\Command\Base;
+
+/**
+ * Class CreateTreeObject
+ *
+ * @package SebastianFeldmann\Git
+ * @author  Sebastian Feldmann <sf@sebastian-feldmann.info>
+ * @link    https://github.com/sebastianfeldmann/git
+ * @since   Class available since Release 3.7.0
+ */
+class CreateTreeObject extends Base
+{
+    /**
+     * Return the command to execute.
+     *
+     * @return string
+     * @throws \RuntimeException
+     */
+    protected function getGitCommand(): string
+    {
+        return 'write-tree';
+    }
+}

--- a/tests/git/Command/DiffIndex/GetUnstagedPatchTest.php
+++ b/tests/git/Command/DiffIndex/GetUnstagedPatchTest.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * This file is part of SebastianFeldmann\Git.
+ *
+ * (c) Sebastian Feldmann <sf@sebastian-feldmann.info>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace SebastianFeldmann\Git\Command\DiffIndex;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class GetUnstagedPatchTest
+ *
+ * @package SebastianFeldmann\Git
+ * @author  Sebastian Feldmann <sf@sebastian-feldmann.info>
+ * @link    https://github.com/sebastianfeldmann/git
+ * @since   Class available since Release 3.7.0
+ */
+class GetUnstagedPatchTest extends TestCase
+{
+    public function testGetAcceptableExitCodes()
+    {
+        $cmd = new GetUnstagedPatch();
+
+        $this->assertSame([0, 1], $cmd->getAcceptableExitCodes());
+    }
+
+    public function testGetUnstagedPatchWithoutTree()
+    {
+        $cmd = new GetUnstagedPatch();
+
+        $this->assertSame(
+            'git diff-index --ignore-submodules --binary --exit-code --no-color --no-ext-diff -- ',
+            $cmd->getCommand()
+        );
+    }
+
+    public function testGetUnstagedPatchWithTree()
+    {
+        $cmd = (new GetUnstagedPatch())->tree('1234567890');
+
+        $this->assertSame(
+            'git diff-index --ignore-submodules --binary --exit-code --no-color --no-ext-diff \'1234567890\' -- ',
+            $cmd->getCommand()
+        );
+    }
+}

--- a/tests/git/Command/WriteTree/CreateTreeObjectTest.php
+++ b/tests/git/Command/WriteTree/CreateTreeObjectTest.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * This file is part of SebastianFeldmann\Git.
+ *
+ * (c) Sebastian Feldmann <sf@sebastian-feldmann.info>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace SebastianFeldmann\Git\Command\WriteTree;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class CreateTreeObjectTest
+ *
+ * @package SebastianFeldmann\Git
+ * @author  Sebastian Feldmann <sf@sebastian-feldmann.info>
+ * @link    https://github.com/sebastianfeldmann/git
+ * @since   Class available since Release 3.7.0
+ */
+class CreateTreeObjectTest extends TestCase
+{
+    public function testCommand()
+    {
+        $cmd = new CreateTreeObject();
+
+        $this->assertSame('git write-tree', $cmd->getCommand());
+    }
+}


### PR DESCRIPTION
This PR provides a command that may be used to generate a binary diff patch of changes in the working tree.

## Example

```php
use SebastianFeldmann\Git;

$repo = new Git\Repository(__DIR__);

$patchOfUnstagedChanges = $repo->getDiffOperator()->getUnstagedPatch();

echo $patchOfUnstagedChanges . PHP_EOL;
```