### PR TITLE
Provide ability to set config params with commands

### DIFF
--- a/tests/git/Command/BaseTest.php
+++ b/tests/git/Command/BaseTest.php
@@ -35,4 +35,50 @@ class BaseTest extends TestCase
             (string) $cmd
         );
     }
+
+    public function testToStringWithConfigParameters(): void
+    {
+        $cmd = new class extends Base {
+            protected function getGitCommand(): string
+            {
+                return 'foo';
+            }
+        };
+
+        $cmd->setConfigParameter('core.autocrlf', false)
+            ->setConfigParameter('core.abbrev', 10)
+            ->setConfigParameter('commit.gpgSign', true)
+            ->setConfigParameter('diff.algorithm', 'patience');
+
+        $this->assertSame(
+            "git -c 'core.autocrlf=false' -c 'core.abbrev=10' "
+                . "-c 'commit.gpgSign=true' -c 'diff.algorithm=patience' foo",
+            (string) $cmd
+        );
+
+        $cmd->setConfigParameter('core.abbrev', null);
+
+        $this->assertSame(
+            "git -c 'core.autocrlf=false' "
+            . "-c 'commit.gpgSign=true' -c 'diff.algorithm=patience' foo",
+            (string) $cmd
+        );
+    }
+
+    public function testToStringWithRootAndConfigParameters(): void
+    {
+        $cmd = new class ('/bar') extends Base {
+            protected function getGitCommand(): string
+            {
+                return 'baz';
+            }
+        };
+
+        $cmd->setConfigParameter('core.autocrlf', false);
+
+        $this->assertSame(
+            "git -C '/bar' -c 'core.autocrlf=false' baz",
+            (string) $cmd
+        );
+    }
 }


### PR DESCRIPTION
This PR provides the ability to set temporary configuration parameters for use with a command. This affects only the command instance on which it is called. It does not affect `~/.gitconfig` or `.git/config`.

## Example

In this example, we pass `-c diff.algorithm=patience` along with the `diff` command.

```php
use SebastianFeldmann\Git;
use SebastianFeldmann\Cli\Command\Runner;

$repo = new Git\Repository(__DIR__);

$diff = new Git\Command\Diff\Compare();
$diff->revisions(
    '10006a7583f79a48eadbe86a55b0b78ee5861ae7',
    '478d486f1b371f4e3b9d65f854e9a560f6a88502'
);

$diff->setConfigParameter('diff.algorithm', 'patience');

$runner = new Runner\Simple();
$result = $runner->run($diff);

echo $result->getStdOut();
```