### PR TITLE
Implement apply command for applying diff patches

### DIFF
--- a/src/Command/Apply/ApplyPatch.php
+++ b/src/Command/Apply/ApplyPatch.php
@@ -1,0 +1,116 @@
+<?php
+
+/**
+ * This file is part of SebastianFeldmann\Git.
+ *
+ * (c) Sebastian Feldmann <sf@sebastian-feldmann.info>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace SebastianFeldmann\Git\Command\Apply;
+
+use SebastianFeldmann\Git\Command\Base;
+
+/**
+ * Class ApplyPatch
+ *
+ * @package SebastianFeldmann\Git
+ * @author  Sebastian Feldmann <sf@sebastian-feldmann.info>
+ * @link    https://github.com/sebastianfeldmann/git
+ * @since   Class available since Release 3.7.0
+ */
+class ApplyPatch extends Base
+{
+    /**
+     * Patch files to apply.
+     *
+     * @var string[]
+     */
+    private $patchFiles = [];
+
+    /**
+     * Action to take when encountering whitespace.
+     *
+     * @var string
+     */
+    private $whitespace = ' --whitespace=\'warn\'';
+
+    /**
+     * Number of leading path components to remove from the diff paths.
+     *
+     * @var string
+     */
+    private $pathComponents = ' -p1';
+
+    /**
+     * Ignore changes in whitespace in context lines.
+     *
+     * @var string
+     */
+    private $ignoreSpaceChange = '';
+
+    /**
+     * Patch files to apply.
+     *
+     * @param string[] $patchFiles
+     * @return \SebastianFeldmann\Git\Command\Apply\ApplyPatch
+     */
+    public function patches(array $patchFiles): ApplyPatch
+    {
+        $this->patchFiles = $patchFiles;
+        return $this;
+    }
+
+    /**
+     * Set the action to take when encountering whitespace.
+     *
+     * @param  string $action
+     * @return \SebastianFeldmann\Git\Command\Apply\ApplyPatch
+     */
+    public function whitespace(string $action = 'warn'): ApplyPatch
+    {
+        $this->whitespace = ' --whitespace=' . escapeshellarg($action);
+        return $this;
+    }
+
+    /**
+     * Set the number of leading path components to remove from the diff paths.
+     *
+     * @param  int $pathComponents
+     * @return \SebastianFeldmann\Git\Command\Apply\ApplyPatch
+     */
+    public function pathComponents(int $pathComponents = 1): ApplyPatch
+    {
+        $this->pathComponents = ' -p' . $pathComponents;
+        return $this;
+    }
+
+    /**
+     * Ignore changes in whitespace in context lines if necessary.
+     *
+     * @param bool $bool
+     * @return \SebastianFeldmann\Git\Command\Apply\ApplyPatch
+     */
+    public function ignoreSpaceChange(bool $bool = true): ApplyPatch
+    {
+        $this->ignoreSpaceChange = $this->useOption('--ignore-space-change', $bool);
+        return $this;
+    }
+
+    /**
+     * Return the command to execute.
+     *
+     * @return string
+     */
+    protected function getGitCommand(): string
+    {
+        return 'apply'
+            . $this->pathComponents
+            . $this->whitespace
+            . $this->ignoreSpaceChange
+            . ' '
+            . implode(' ', array_map('escapeshellarg', $this->patchFiles));
+    }
+}

--- a/src/Operator/Diff.php
+++ b/src/Operator/Diff.php
@@ -11,6 +11,7 @@
 
 namespace SebastianFeldmann\Git\Operator;
 
+use SebastianFeldmann\Git\Command\Apply\ApplyPatch;
 use SebastianFeldmann\Git\Command\Diff\Compare;
 use SebastianFeldmann\Git\Command\DiffIndex\GetUnstagedPatch;
 use SebastianFeldmann\Git\Command\DiffTree\ChangedFiles;
@@ -100,5 +101,28 @@ class Diff extends Base
         }
 
         return null;
+    }
+
+    /**
+     * Applies the supplied diff patches to files.
+     *
+     * @param string[] $patches An array of paths to patch files.
+     * @param bool $disableAutoCrlfSetting If true, explicitly set core.autocrlf
+     *     to "false" to override the global Git configuration.
+     * @return bool True if the patches apply cleanly.
+     */
+    public function applyPatches(array $patches, bool $disableAutoCrlfSetting = false): bool
+    {
+        $cmd = (new ApplyPatch($this->repo->getRoot()))
+            ->patches($patches)
+            ->whitespace('nowarn');
+
+        if ($disableAutoCrlfSetting === true) {
+            $cmd->setConfigParameter('core.autocrlf', false);
+        }
+
+        $result = $this->runner->run($cmd);
+
+        return $result->isSuccessful();
     }
 }

--- a/tests/git/Command/Apply/ApplyPatchTest.php
+++ b/tests/git/Command/Apply/ApplyPatchTest.php
@@ -1,0 +1,76 @@
+<?php
+
+/**
+ * This file is part of SebastianFeldmann\Git.
+ *
+ * (c) Sebastian Feldmann <sf@sebastian-feldmann.info>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace SebastianFeldmann\Git\Command\Apply;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class ApplyPatchTest
+ *
+ * @package SebastianFeldmann\Git
+ * @author  Sebastian Feldmann <sf@sebastian-feldmann.info>
+ * @link    https://github.com/sebastianfeldmann/git
+ * @since   Class available since Release 3.7.0
+ */
+class ApplyPatchTest extends TestCase
+{
+    public function testDefaultCommand(): void
+    {
+        $command = new ApplyPatch();
+
+        $this->assertSame(
+            'git apply -p1 --whitespace=\'warn\' ',
+            $command->getCommand()
+        );
+    }
+
+    public function testPatchFiles(): void
+    {
+        $command = new ApplyPatch();
+        $command->patches(['foo.patch', 'bar.patch']);
+
+        $this->assertSame(
+            'git apply -p1 --whitespace=\'warn\' \'foo.patch\' \'bar.patch\'',
+            $command->getCommand()
+        );
+    }
+
+    public function testWhitespace(): void
+    {
+        $command = (new ApplyPatch())->patches(['foo.patch'])->whitespace('nowarn');
+
+        $this->assertSame(
+            'git apply -p1 --whitespace=\'nowarn\' \'foo.patch\'',
+            $command->getCommand()
+        );
+    }
+
+    public function testPathComponents(): void
+    {
+        $command = (new ApplyPatch())->patches(['foo.patch'])->pathComponents(3);
+
+        $this->assertSame(
+            'git apply -p3 --whitespace=\'warn\' \'foo.patch\'',
+            $command->getCommand()
+        );
+    }
+
+    public function testIgnoreSpaceChange(): void
+    {
+        $command = (new ApplyPatch())->patches(['foo.patch'])->ignoreSpaceChange();
+
+        $this->assertSame(
+            'git apply -p1 --whitespace=\'warn\' --ignore-space-change \'foo.patch\'',
+            $command->getCommand()
+        );
+    }
+}

--- a/tests/git/Command/BaseTest.php
+++ b/tests/git/Command/BaseTest.php
@@ -35,4 +35,50 @@ class BaseTest extends TestCase
             (string) $cmd
         );
     }
+
+    public function testToStringWithConfigParameters(): void
+    {
+        $cmd = new class extends Base {
+            protected function getGitCommand(): string
+            {
+                return 'foo';
+            }
+        };
+
+        $cmd->setConfigParameter('core.autocrlf', false)
+            ->setConfigParameter('core.abbrev', 10)
+            ->setConfigParameter('commit.gpgSign', true)
+            ->setConfigParameter('diff.algorithm', 'patience');
+
+        $this->assertSame(
+            "git -c 'core.autocrlf=false' -c 'core.abbrev=10' "
+                . "-c 'commit.gpgSign=true' -c 'diff.algorithm=patience' foo",
+            (string) $cmd
+        );
+
+        $cmd->setConfigParameter('core.abbrev', null);
+
+        $this->assertSame(
+            "git -c 'core.autocrlf=false' "
+            . "-c 'commit.gpgSign=true' -c 'diff.algorithm=patience' foo",
+            (string) $cmd
+        );
+    }
+
+    public function testToStringWithRootAndConfigParameters(): void
+    {
+        $cmd = new class ('/bar') extends Base {
+            protected function getGitCommand(): string
+            {
+                return 'baz';
+            }
+        };
+
+        $cmd->setConfigParameter('core.autocrlf', false);
+
+        $this->assertSame(
+            "git -C '/bar' -c 'core.autocrlf=false' baz",
+            (string) $cmd
+        );
+    }
 }


### PR DESCRIPTION
Implement the `apply` command to provide the ability to apply diff patches to the working tree.

This PR also includes the commit from #28. I wanted to submit them separately for separate review, but if you look at the total changes in this PR, you'll see the changes for both commits, since #28 is required to make this work.

## Example

In this example, you should be able to get an idea of the direction I'm heading in order to implement the CaptainHook feature I proposed here: https://github.com/captainhookphp/captainhook/issues/122

```php
use SebastianFeldmann\Git;

$repo = new Git\Repository(__DIR__);
$diff = $repo->getDiffOperator();

// Create patch from working tree.
$patchFile = tempnam(sys_get_temp_dir(), 'CaptainHook');
file_put_contents($patchFile, $diff->getUnstagedPatch());

// Reset working tree.
exec('git checkout -- .', $output, $exitCode);

$applied = true;

try {
    // Apply patch back to working tree.
    if (!$diff->applyPatches([$patchFile])) {
        if (!$diff->applyPatches([$patchFile], true)) {
            $applied = false;
        }
    }
} finally {
    if ($applied) {
        fwrite(STDOUT, 'Cleanly applied patch file to working tree: ' . $patchFile);
    } else {
        fwrite(STDERR, 'Could not cleanly apply patch file to working tree: ' . $patchFile);
    }
}
```