### PR TITLE
Implement command to checkout/restore working tree

### DIFF
--- a/src/Command/Checkout/RestoreWorkingTree.php
+++ b/src/Command/Checkout/RestoreWorkingTree.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * This file is part of SebastianFeldmann\Git.
+ *
+ * (c) Sebastian Feldmann <sf@sebastian-feldmann.info>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace SebastianFeldmann\Git\Command\Checkout;
+
+use SebastianFeldmann\Git\Command\Base;
+
+/**
+ * Class RestoreWorkingTree
+ *
+ * @package SebastianFeldmann\Git
+ * @author  Sebastian Feldmann <sf@sebastian-feldmann.info>
+ * @link    https://github.com/sebastianfeldmann/git
+ * @since   Class available since Release 3.7.0
+ */
+class RestoreWorkingTree extends Base
+{
+    /**
+     * Files and directories to restore.
+     *
+     * @var string[]
+     */
+    private $files = ['.'];
+
+    /**
+     * Limits the paths affected by the operation to those specified here.
+     *
+     * @param array $files
+     *
+     * @return \SebastianFeldmann\Git\Command\Checkout\RestoreWorkingTree
+     */
+    public function files(array $files): RestoreWorkingTree
+    {
+        $this->files = $files;
+        return $this;
+    }
+
+    /**
+     * Return the command to execute.
+     *
+     * @return string
+     */
+    protected function getGitCommand(): string
+    {
+        return 'checkout --quiet'
+            . ' -- '
+            . implode(' ', array_map('escapeshellarg', $this->files));
+    }
+}

--- a/src/Operator/Status.php
+++ b/src/Operator/Status.php
@@ -11,6 +11,7 @@
 
 namespace SebastianFeldmann\Git\Operator;
 
+use SebastianFeldmann\Git\Command\Checkout\RestoreWorkingTree;
 use SebastianFeldmann\Git\Command\Status\WorkingTreeStatus;
 use SebastianFeldmann\Git\Command\Status\Porcelain\PathList;
 
@@ -36,5 +37,21 @@ class Status extends Base
         $result = $this->runner->run($cmd, new PathList());
 
         return $result->getFormattedOutput();
+    }
+
+    /**
+     * Performs a checkout (restore) operation on the given paths
+     * (or the entire repo, by default).
+     *
+     * @param string[] $limitToPaths
+     * @return bool
+     */
+    public function restoreWorkingTree(array $limitToPaths = ['.']): bool
+    {
+        $cmd = (new RestoreWorkingTree($this->repo->getRoot()))->files($limitToPaths);
+
+        $result = $this->runner->run($cmd);
+
+        return $result->isSuccessful();
     }
 }

--- a/tests/git/Command/Checkout/RestoreWorkingTreeTest.php
+++ b/tests/git/Command/Checkout/RestoreWorkingTreeTest.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * This file is part of SebastianFeldmann\Git.
+ *
+ * (c) Sebastian Feldmann <sf@sebastian-feldmann.info>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace SebastianFeldmann\Git\Command\Checkout;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class RestoreWorkingTreeTest
+ *
+ * @package SebastianFeldmann\Git
+ * @author  Sebastian Feldmann <sf@sebastian-feldmann.info>
+ * @link    https://github.com/sebastianfeldmann/git
+ * @since   Class available since Release 3.7.0
+ */
+class RestoreWorkingTreeTest extends TestCase
+{
+    public function testDefault(): void
+    {
+        $command = new RestoreWorkingTree();
+
+        $this->assertSame('git checkout --quiet -- \'.\'', $command->getCommand());
+    }
+
+    public function testFiles(): void
+    {
+        $command = new RestoreWorkingTree();
+        $command = $command->files([
+            "foo/*",
+            "foo bar.txt",
+            "foo' 'bar.txt",
+            "fooBar.txt",
+        ]);
+
+        $this->assertSame(
+            "git checkout --quiet -- 'foo/*' 'foo bar.txt' 'foo'\'' '\''bar.txt' 'fooBar.txt'",
+            $command->getCommand()
+        );
+    }
+}


### PR DESCRIPTION
This PR provides the ability to run `checkout` in the local working tree to restore all the files (wipe out their local changes).

## Example

```php
use SebastianFeldmann\Git;

$repo = new Git\Repository(__DIR__);
$diff = $repo->getDiffOperator();
$unstagedChanges = $diff->getUnstagedPatch();

$repo->getStatusOperator()->restoreWorkingTree();

echo "BEFORE RESTORING WORKING TREE:\n";
echo "------------------------------\n";
echo $unstagedChanges;
echo "\n\n\n";

echo "AFTER RESTORING WORKING TREE:\n";
echo "------------------------------\n";
echo $diff->getUnstagedPatch();
echo "\n\n\n";
```