### PR TITLE
Improvements to Diff

### DIFF
--- a/src/Command/Diff/Compare.php
+++ b/src/Command/Diff/Compare.php
@@ -139,7 +139,7 @@ class Compare extends Base
      */
     protected function getGitCommand(): string
     {
-        return 'diff'
+        return 'diff --no-ext-diff'
                . $this->unified
                . $this->ignoreWhitespaces
                . $this->ignoreEOL

--- a/src/Command/Diff/Compare.php
+++ b/src/Command/Diff/Compare.php
@@ -66,6 +66,13 @@ class Compare extends Base
     private $unified = '';
 
     /**
+     * View the changes staged for the next commit.
+     *
+     * @var string
+     */
+    private $staged = '';
+
+    /**
      * Compare two given revisions.
      *
      * @param  string $from
@@ -79,14 +86,40 @@ class Compare extends Base
     }
 
     /**
+     * Compares the working tree or index to a given commit-ish
+     *
+     * @param  string $to
+     * @return \SebastianFeldmann\Git\Command\Diff\Compare
+     */
+    public function to(string $to = 'HEAD'): Compare
+    {
+        $this->compare = escapeshellarg($to);
+        return $this;
+    }
+
+    /**
      * Compares the index to a given commit hash
+     *
+     * This method is a shortcut for calling {@see staged()} and {@see to()}.
      *
      * @param  string $to
      * @return \SebastianFeldmann\Git\Command\Diff\Compare
      */
     public function indexTo(string $to = 'HEAD'): Compare
     {
-        $this->compare = '--staged ' . $to;
+        return $this->staged()->to($to);
+    }
+
+    /**
+     * View the changes staged for the next commit relative to the <commit>
+     * named with {@see to()}.
+     *
+     * @param  bool $bool
+     * @return \SebastianFeldmann\Git\Command\Diff\Compare
+     */
+    public function staged(bool $bool = true): Compare
+    {
+        $this->stats = $this->useOption('--staged', $bool);
         return $this;
     }
 
@@ -164,6 +197,8 @@ class Compare extends Base
                . $this->ignoreSubmodules
                . $this->ignoreEOL
                . $this->stats
-               . ' ' . $this->compare;
+               . $this->staged
+               . ' ' . $this->compare
+               . ' -- ';
     }
 }

--- a/src/Command/Diff/Compare.php
+++ b/src/Command/Diff/Compare.php
@@ -52,6 +52,13 @@ class Compare extends Base
     private $ignoreWhitespaces = '';
 
     /**
+     * Ignore submodules.
+     *
+     * @var string
+     */
+    private $ignoreSubmodules = '';
+
+    /**
      * Number of context lines before and after the diff
      *
      * @var string
@@ -132,6 +139,18 @@ class Compare extends Base
     }
 
     /**
+     * Set ignore submodules.
+     *
+     * @param  bool $bool
+     * @return \SebastianFeldmann\Git\Command\Diff\Compare
+     */
+    public function ignoreSubmodules(bool $bool = true): Compare
+    {
+        $this->ignoreSubmodules = $this->useOption('--ignore-submodules', $bool);
+        return $this;
+    }
+
+    /**
      * Return the command to execute.
      *
      * @return string
@@ -142,6 +161,7 @@ class Compare extends Base
         return 'diff --no-ext-diff'
                . $this->unified
                . $this->ignoreWhitespaces
+               . $this->ignoreSubmodules
                . $this->ignoreEOL
                . $this->stats
                . ' ' . $this->compare;

--- a/src/Command/Diff/Compare/FullDiffList.php
+++ b/src/Command/Diff/Compare/FullDiffList.php
@@ -264,7 +264,7 @@ class FullDiffList implements OutputFormatter
     private function isChangePositionLine(string $line): bool
     {
         $matches = [];
-        if (preg_match('#^@@ (\-[0-9,]{3,} \+[0-9,]{3,}) @@ ?(.*)$#', $line, $matches)) {
+        if (preg_match('#^@@ (-\d+(?:,\d+)? \+\d+(?:,\d+)?) @@ ?(.*)$#', $line, $matches)) {
             $this->currentPosition                        = $matches[1];
             $this->currentChanges[$this->currentPosition] = new Change($matches[1], $matches[2]);
             return true;

--- a/src/Command/DiffIndex/GetStagedFiles.php
+++ b/src/Command/DiffIndex/GetStagedFiles.php
@@ -31,6 +31,6 @@ class GetStagedFiles extends Base
      */
     protected function getGitCommand(): string
     {
-        return 'diff-index --cached --name-status HEAD';
+        return 'diff-index --no-ext-diff --cached --name-status HEAD';
     }
 }

--- a/src/Command/DiffTree/ChangedFiles.php
+++ b/src/Command/DiffTree/ChangedFiles.php
@@ -61,7 +61,7 @@ class ChangedFiles extends Base
      */
     protected function getGitCommand(): string
     {
-        return 'diff-tree --no-commit-id --name-only -r ' . $this->getVersionsToCompare();
+        return 'diff-tree --no-ext-diff --no-commit-id --name-only -r ' . $this->getVersionsToCompare();
     }
 
     /**

--- a/src/Diff/Change.php
+++ b/src/Diff/Change.php
@@ -28,16 +28,16 @@ class Change
     private $header;
 
     /**
-     * Pre range ['from' => x, 'to' => y]
+     * Pre range.
      *
-     * @var array
+     * @var array{from: int|null, to: int|null}
      */
     private $pre;
 
     /**
-     * Post range ['from' => x, 'to' => y]
+     * Post range.
      *
-     * @var array
+     * @var array{from: int|null, to: int|null}
      */
     private $post;
 
@@ -137,10 +137,28 @@ class Change
     private function splitRanges(string $ranges): void
     {
         $matches = [];
-        if (!preg_match('#^[\-|\+]{1}([0-9]+),([0-9]+) [\-\+]{1}([0-9]+),([0-9]+)$#', $ranges, $matches)) {
+        if (!preg_match('#^[\-|+](\d+)(?:,(\d+))? [\-+](\d+)(?:,(\d+))?$#', $ranges, $matches)) {
             throw new \RuntimeException('invalid ranges: ' . $ranges);
         }
-        $this->pre  = ['from' => (int)$matches[1], 'to' => (int)$matches[2]];
-        $this->post = ['from' => (int)$matches[3], 'to' => (int)$matches[4]];
+
+        $matches = array_map(
+            function ($value) {
+                if (strlen($value) === 0) {
+                    return null;
+                }
+                return $value;
+            },
+            $matches
+        );
+
+        $this->pre = [
+            'from' => isset($matches[1]) ? (int) $matches[1] : null,
+            'to' => isset($matches[2]) ? (int) $matches[2] : null,
+        ];
+
+        $this->post = [
+            'from' => isset($matches[3]) ? (int) $matches[3] : null,
+            'to' => isset($matches[4]) ? (int) $matches[4] : null,
+        ];
     }
 }

--- a/src/Operator/Diff.php
+++ b/src/Operator/Diff.php
@@ -45,7 +45,7 @@ class Diff extends Base
     }
 
     /**
-     * Returns a list of files and their changes
+     * Returns a list of files and their changes staged for the next commit
      *
      * @param  string $to
      * @return \SebastianFeldmann\Git\Diff\File[]
@@ -55,6 +55,23 @@ class Diff extends Base
         $compare = (new Compare($this->repo->getRoot()))->indexTo($to)
                                                         ->withContextLines(0)
                                                         ->ignoreWhitespacesAtEndOfLine();
+
+        $result = $this->runner->run($compare, new Compare\FullDiffList());
+
+        return $result->getFormattedOutput();
+    }
+
+    /**
+     * Returns a list of files and their changes not yet staged
+     *
+     * @param string $to
+     * @return \SebastianFeldmann\Git\Diff\File[]
+     */
+    public function compareTo(string $to = 'HEAD'): iterable
+    {
+        $compare = (new Compare($this->repo->getRoot()))->to($to)
+                                                        ->ignoreSubmodules()
+                                                        ->withContextLines(0);
 
         $result = $this->runner->run($compare, new Compare\FullDiffList());
 

--- a/tests/git/Command/Diff/Compare/FullDiffList-01.diff
+++ b/tests/git/Command/Diff/Compare/FullDiffList-01.diff
@@ -1,0 +1,140 @@
+diff --git a/src/Command/Diff/Compare.php b/src/Command/Diff/Compare.php
+index a2a41d1..a17881b 100644
+--- a/src/Command/Diff/Compare.php
++++ b/src/Command/Diff/Compare.php
+@@ -67,0 +68,7 @@ class Compare extends Base
++    /**
++     * View the changes staged for the next commit.
++     *
++     * @var string
++     */
++    private $staged = '';
++
+@@ -80,0 +88,12 @@ class Compare extends Base
++    /**
++     * Compares the working tree or index to a given commit-ish
++     *
++     * @param  string $to
++     * @return \SebastianFeldmann\Git\Command\Diff\Compare
++     */
++    public function to(string $to = 'HEAD'): Compare
++    {
++        $this->compare = $to;
++        return $this;
++    }
++
+@@ -83,0 +103,2 @@ class Compare extends Base
++     * This method is a shortcut for calling {@see staged()} and {@see to()}.
++     *
+@@ -89 +110,13 @@ class Compare extends Base
+-        $this->compare = '--staged ' . $to;
++        return $this->staged()->to($to);
++    }
++
++    /**
++     * View the changes staged for the next commit relative to the <commit>
++     * named with {@see to()}.
++     *
++     * @param  bool $bool
++     * @return \SebastianFeldmann\Git\Command\Diff\Compare
++     */
++    public function staged(bool $bool = true): Compare
++    {
++        $this->stats = $this->useOption('--staged', $bool);
+@@ -167 +200,3 @@ class Compare extends Base
+-               . ' ' . $this->compare;
++               . $this->staged
++               . ' ' . $this->compare
++               . ' -- ';
+diff --git a/src/Command/Diff/Compare/FullDiffList.php b/src/Command/Diff/Compare/FullDiffList.php
+index 4e85eba..f5e9ca7 100644
+--- a/src/Command/Diff/Compare/FullDiffList.php
++++ b/src/Command/Diff/Compare/FullDiffList.php
+@@ -267 +267 @@ class FullDiffList implements OutputFormatter
+-        if (preg_match('#^@@ (\-[0-9,]{3,} \+[0-9,]{3,}) @@ ?(.*)$#', $line, $matches)) {
++        if (preg_match('#^@@ (-\d+(?:,\d+)? \+\d+(?:,\d+)?) @@ ?(.*)$#', $line, $matches)) {
+diff --git a/src/Diff/Change.php b/src/Diff/Change.php
+index ff95c05..972b5db 100644
+--- a/src/Diff/Change.php
++++ b/src/Diff/Change.php
+@@ -31 +31 @@ class Change
+-     * Pre range ['from' => x, 'to' => y]
++     * Pre range.
+@@ -33 +33 @@ class Change
+-     * @var array
++     * @var array{from: int|null, to: int|null}
+@@ -38 +38 @@ class Change
+-     * Post range ['from' => x, 'to' => y]
++     * Post range.
+@@ -40 +40 @@ class Change
+-     * @var array
++     * @var array{from: int|null, to: int|null}
+@@ -140 +140 @@ class Change
+-        if (!preg_match('#^[\-|\+]{1}([0-9]+),([0-9]+) [\-\+]{1}([0-9]+),([0-9]+)$#', $ranges, $matches)) {
++        if (!preg_match('#^[\-|+](\d+)(?:,(\d+))? [\-+](\d+)(?:,(\d+))?$#', $ranges, $matches)) {
+@@ -143,2 +143,10 @@ class Change
+-        $this->pre  = ['from' => (int)$matches[1], 'to' => (int)$matches[2]];
+-        $this->post = ['from' => (int)$matches[3], 'to' => (int)$matches[4]];
++
++        $this->pre = [
++            'from' => isset($matches[1]) ? (int) $matches[1] : null,
++            'to' => isset($matches[2]) ? (int) $matches[2] : null,
++        ];
++
++        $this->post = [
++            'from' => isset($matches[3]) ? (int) $matches[3] : null,
++            'to' => isset($matches[4]) ? (int) $matches[4] : null,
++        ];
+diff --git a/src/Operator/Diff.php b/src/Operator/Diff.php
+index e05d7bb..b93b976 100644
+--- a/src/Operator/Diff.php
++++ b/src/Operator/Diff.php
+@@ -48 +48 @@ class Diff extends Base
+-     * Returns a list of files and their changes
++     * Returns a list of files and their changes staged for the next commit
+@@ -63,0 +64,17 @@ class Diff extends Base
++    /**
++     * Returns a list of files and their changes not yet staged
++     *
++     * @param string $to
++     * @return \SebastianFeldmann\Git\Diff\File[]
++     */
++    public function compareTo(string $to = 'HEAD'): iterable
++    {
++        $compare = (new Compare($this->repo->getRoot()))->to($to)
++                                                        ->ignoreSubmodules()
++                                                        ->withContextLines(0);
++
++        $result = $this->runner->run($compare, new Compare\FullDiffList());
++
++        return $result->getFormattedOutput();
++    }
++
+diff --git a/tests/git/Command/Diff/CompareTest.php b/tests/git/Command/Diff/CompareTest.php
+index a67881c..c895131 100644
+--- a/tests/git/Command/Diff/CompareTest.php
++++ b/tests/git/Command/Diff/CompareTest.php
+@@ -34 +34 @@ class CompareTest extends TestCase
+-        $this->assertEquals('git diff --no-ext-diff \'1.0.0\' \'1.1.0\'', $compare->getCommand());
++        $this->assertEquals('git diff --no-ext-diff \'1.0.0\' \'1.1.0\' -- ', $compare->getCommand());
+@@ -46 +46 @@ class CompareTest extends TestCase
+-        $this->assertEquals('git diff --no-ext-diff --numstat \'1.0.0\' \'1.1.0\'', $compare->getCommand());
++        $this->assertEquals('git diff --no-ext-diff --numstat \'1.0.0\' \'1.1.0\' -- ', $compare->getCommand());
+@@ -59 +59 @@ class CompareTest extends TestCase
+-            'git diff --no-ext-diff --ignore-space-at-eol \'1.0.0\' \'1.1.0\'',
++            'git diff --no-ext-diff --ignore-space-at-eol \'1.0.0\' \'1.1.0\' -- ',
+@@ -72 +72 @@ class CompareTest extends TestCase
+-        $this->assertEquals('git diff --no-ext-diff --staged HEAD', $compare->getCommand());
++        $this->assertEquals('git diff --no-ext-diff --staged HEAD -- ', $compare->getCommand());
+@@ -84 +84 @@ class CompareTest extends TestCase
+-        $this->assertEquals('git diff --no-ext-diff --unified=2 --staged HEAD', $compare->getCommand());
++        $this->assertEquals('git diff --no-ext-diff --unified=2 --staged HEAD -- ', $compare->getCommand());
+@@ -96 +96 @@ class CompareTest extends TestCase
+-        $this->assertEquals('git diff --no-ext-diff -w \'1.0.0\' \'1.1.0\'', $compare->getCommand());
++        $this->assertEquals('git diff --no-ext-diff -w \'1.0.0\' \'1.1.0\' -- ', $compare->getCommand());
+@@ -110 +110 @@ class CompareTest extends TestCase
+-            'git diff --no-ext-diff -w --ignore-space-at-eol \'1.0.0\' \'1.1.0\'',
++            'git diff --no-ext-diff -w --ignore-space-at-eol \'1.0.0\' \'1.1.0\' -- ',
+@@ -120 +120 @@ class CompareTest extends TestCase
+-        $this->assertEquals('git diff --no-ext-diff --ignore-submodules ', $compare->getCommand());
++        $this->assertEquals('git diff --no-ext-diff --ignore-submodules  -- ', $compare->getCommand());

--- a/tests/git/Command/Diff/Compare/FullDiffListTest.php
+++ b/tests/git/Command/Diff/Compare/FullDiffListTest.php
@@ -227,4 +227,49 @@ class FullDiffListTest extends TestCase
         $this->assertEquals('created', $files[1]->getOperation());
         $this->assertCount(5, $files[1]->getChanges()[0]->getLines());
     }
+
+    public function testFullDiffList01(): void
+    {
+        $output = file(__DIR__ . '/FullDiffList-01.diff', FILE_IGNORE_NEW_LINES);
+
+        $formatter = new FullDiffList();
+
+        /** @var File[] $files */
+        $files = $formatter->format($output);
+
+        $this->assertCount(5, $files);
+
+        $firstFile = $files[0];
+        $firstFileChanges = $firstFile->getChanges();
+
+        $this->assertSame('src/Command/Diff/Compare.php', $firstFile->getName());
+        $this->assertCount(5, $firstFileChanges);
+        $this->assertSame(['from' => 67, 'to' => 0], $firstFileChanges[0]->getPre());
+        $this->assertSame(['from' => 68, 'to' => 7], $firstFileChanges[0]->getPost());
+        $this->assertSame(['from' => 80, 'to' => 0], $firstFileChanges[1]->getPre());
+        $this->assertSame(['from' => 88, 'to' => 12], $firstFileChanges[1]->getPost());
+        $this->assertSame(['from' => 83, 'to' => 0], $firstFileChanges[2]->getPre());
+        $this->assertSame(['from' => 103, 'to' => 2], $firstFileChanges[2]->getPost());
+        $this->assertSame(['from' => 89, 'to' => null], $firstFileChanges[3]->getPre());
+        $this->assertSame(['from' => 110, 'to' => 13], $firstFileChanges[3]->getPost());
+        $this->assertSame(['from' => 167, 'to' => null], $firstFileChanges[4]->getPre());
+        $this->assertSame(['from' => 200, 'to' => 3], $firstFileChanges[4]->getPost());
+
+        $secondFile = $files[1];
+        $secondFileChanges = $secondFile->getChanges();
+
+        $this->assertSame('src/Command/Diff/Compare/FullDiffList.php', $secondFile->getName());
+        $this->assertCount(1, $secondFileChanges);
+        $this->assertSame(['from' => 267, 'to' => null], $secondFileChanges[0]->getPre());
+        $this->assertSame(['from' => 267, 'to' => null], $secondFileChanges[0]->getPost());
+
+        $this->assertSame('src/Diff/Change.php', $files[2]->getName());
+        $this->assertCount(6, $files[2]->getChanges());
+
+        $this->assertSame('src/Operator/Diff.php', $files[3]->getName());
+        $this->assertCount(2, $files[3]->getChanges());
+
+        $this->assertSame('tests/git/Command/Diff/CompareTest.php', $files[4]->getName());
+        $this->assertCount(8, $files[4]->getChanges());
+    }
 }

--- a/tests/git/Command/Diff/CompareTest.php
+++ b/tests/git/Command/Diff/CompareTest.php
@@ -31,7 +31,7 @@ class CompareTest extends TestCase
         $compare = new Compare();
         $compare->revisions('1.0.0', '1.1.0');
 
-        $this->assertEquals('git diff --no-ext-diff \'1.0.0\' \'1.1.0\'', $compare->getCommand());
+        $this->assertEquals('git diff --no-ext-diff \'1.0.0\' \'1.1.0\' -- ', $compare->getCommand());
     }
 
     /**
@@ -43,7 +43,7 @@ class CompareTest extends TestCase
         $compare->revisions('1.0.0', '1.1.0');
         $compare->statsOnly();
 
-        $this->assertEquals('git diff --no-ext-diff --numstat \'1.0.0\' \'1.1.0\'', $compare->getCommand());
+        $this->assertEquals('git diff --no-ext-diff --numstat \'1.0.0\' \'1.1.0\' -- ', $compare->getCommand());
     }
 
     /**
@@ -56,7 +56,7 @@ class CompareTest extends TestCase
         $compare->ignoreWhitespacesAtEndOfLine();
 
         $this->assertEquals(
-            'git diff --no-ext-diff --ignore-space-at-eol \'1.0.0\' \'1.1.0\'',
+            'git diff --no-ext-diff --ignore-space-at-eol \'1.0.0\' \'1.1.0\' -- ',
             $compare->getCommand()
         );
     }
@@ -69,7 +69,7 @@ class CompareTest extends TestCase
         $compare = new Compare();
         $compare->indexTo();
 
-        $this->assertEquals('git diff --no-ext-diff --staged HEAD', $compare->getCommand());
+        $this->assertEquals('git diff --no-ext-diff --staged \'HEAD\' -- ', $compare->getCommand());
     }
 
     /**
@@ -81,7 +81,7 @@ class CompareTest extends TestCase
         $compare->indexTo()->withContextLines(2);
 
 
-        $this->assertEquals('git diff --no-ext-diff --unified=2 --staged HEAD', $compare->getCommand());
+        $this->assertEquals('git diff --no-ext-diff --unified=2 --staged \'HEAD\' -- ', $compare->getCommand());
     }
 
     /**
@@ -93,7 +93,7 @@ class CompareTest extends TestCase
         $compare->revisions('1.0.0', '1.1.0');
         $compare->ignoreWhitespaces();
 
-        $this->assertEquals('git diff --no-ext-diff -w \'1.0.0\' \'1.1.0\'', $compare->getCommand());
+        $this->assertEquals('git diff --no-ext-diff -w \'1.0.0\' \'1.1.0\' -- ', $compare->getCommand());
     }
 
     /**
@@ -107,7 +107,7 @@ class CompareTest extends TestCase
                 ->ignoreWhitespaces();
 
         $this->assertEquals(
-            'git diff --no-ext-diff -w --ignore-space-at-eol \'1.0.0\' \'1.1.0\'',
+            'git diff --no-ext-diff -w --ignore-space-at-eol \'1.0.0\' \'1.1.0\' -- ',
             $compare->getCommand()
         );
     }
@@ -117,6 +117,30 @@ class CompareTest extends TestCase
         $compare = new Compare();
         $compare->ignoreSubmodules();
 
-        $this->assertEquals('git diff --no-ext-diff --ignore-submodules ', $compare->getCommand());
+        $this->assertEquals('git diff --no-ext-diff --ignore-submodules  -- ', $compare->getCommand());
+    }
+
+    public function testStaged(): void
+    {
+        $compare = new Compare();
+        $compare->staged();
+
+        $this->assertEquals('git diff --no-ext-diff --staged  -- ', $compare->getCommand());
+    }
+
+    public function testToWithDefaultParam(): void
+    {
+        $compare = new Compare();
+        $compare->to();
+
+        $this->assertEquals('git diff --no-ext-diff \'HEAD\' -- ', $compare->getCommand());
+    }
+
+    public function testToWithPassedParam(): void
+    {
+        $compare = new Compare();
+        $compare->to('foobar');
+
+        $this->assertEquals('git diff --no-ext-diff \'foobar\' -- ', $compare->getCommand());
     }
 }

--- a/tests/git/Command/Diff/CompareTest.php
+++ b/tests/git/Command/Diff/CompareTest.php
@@ -111,4 +111,12 @@ class CompareTest extends TestCase
             $compare->getCommand()
         );
     }
+
+    public function testIgnoreSubmodules(): void
+    {
+        $compare = new Compare();
+        $compare->ignoreSubmodules();
+
+        $this->assertEquals('git diff --no-ext-diff --ignore-submodules ', $compare->getCommand());
+    }
 }

--- a/tests/git/Command/Diff/CompareTest.php
+++ b/tests/git/Command/Diff/CompareTest.php
@@ -31,7 +31,7 @@ class CompareTest extends TestCase
         $compare = new Compare();
         $compare->revisions('1.0.0', '1.1.0');
 
-        $this->assertEquals('git diff \'1.0.0\' \'1.1.0\'', $compare->getCommand());
+        $this->assertEquals('git diff --no-ext-diff \'1.0.0\' \'1.1.0\'', $compare->getCommand());
     }
 
     /**
@@ -43,7 +43,7 @@ class CompareTest extends TestCase
         $compare->revisions('1.0.0', '1.1.0');
         $compare->statsOnly();
 
-        $this->assertEquals('git diff --numstat \'1.0.0\' \'1.1.0\'', $compare->getCommand());
+        $this->assertEquals('git diff --no-ext-diff --numstat \'1.0.0\' \'1.1.0\'', $compare->getCommand());
     }
 
     /**
@@ -55,7 +55,10 @@ class CompareTest extends TestCase
         $compare->revisions('1.0.0', '1.1.0');
         $compare->ignoreWhitespacesAtEndOfLine();
 
-        $this->assertEquals('git diff --ignore-space-at-eol \'1.0.0\' \'1.1.0\'', $compare->getCommand());
+        $this->assertEquals(
+            'git diff --no-ext-diff --ignore-space-at-eol \'1.0.0\' \'1.1.0\'',
+            $compare->getCommand()
+        );
     }
 
     /**
@@ -66,7 +69,7 @@ class CompareTest extends TestCase
         $compare = new Compare();
         $compare->indexTo();
 
-        $this->assertEquals('git diff --staged HEAD', $compare->getCommand());
+        $this->assertEquals('git diff --no-ext-diff --staged HEAD', $compare->getCommand());
     }
 
     /**
@@ -78,7 +81,7 @@ class CompareTest extends TestCase
         $compare->indexTo()->withContextLines(2);
 
 
-        $this->assertEquals('git diff --unified=2 --staged HEAD', $compare->getCommand());
+        $this->assertEquals('git diff --no-ext-diff --unified=2 --staged HEAD', $compare->getCommand());
     }
 
     /**
@@ -90,7 +93,7 @@ class CompareTest extends TestCase
         $compare->revisions('1.0.0', '1.1.0');
         $compare->ignoreWhitespaces();
 
-        $this->assertEquals('git diff -w \'1.0.0\' \'1.1.0\'', $compare->getCommand());
+        $this->assertEquals('git diff --no-ext-diff -w \'1.0.0\' \'1.1.0\'', $compare->getCommand());
     }
 
     /**
@@ -103,6 +106,9 @@ class CompareTest extends TestCase
                 ->ignoreWhitespacesAtEndOfLine()
                 ->ignoreWhitespaces();
 
-        $this->assertEquals('git diff -w --ignore-space-at-eol \'1.0.0\' \'1.1.0\'', $compare->getCommand());
+        $this->assertEquals(
+            'git diff --no-ext-diff -w --ignore-space-at-eol \'1.0.0\' \'1.1.0\'',
+            $compare->getCommand()
+        );
     }
 }

--- a/tests/git/Command/DiffIndex/GetStagedFilesTest.php
+++ b/tests/git/Command/DiffIndex/GetStagedFilesTest.php
@@ -31,6 +31,6 @@ class GetStagedFilesTest extends TestCase
         $cmd = new GetStagedFiles();
         $exe = $cmd->getCommand();
 
-        $this->assertEquals('git diff-index --cached --name-status HEAD', $exe);
+        $this->assertEquals('git diff-index --no-ext-diff --cached --name-status HEAD', $exe);
     }
 }

--- a/tests/git/Command/DiffTree/ChangedFilesTest.php
+++ b/tests/git/Command/DiffTree/ChangedFilesTest.php
@@ -33,7 +33,10 @@ class ChangedFilesTest extends TestCase
         $changed->fromRevision('1.0.0')
                 ->toRevision('1.1.0');
 
-        $this->assertEquals('git diff-tree --no-commit-id --name-only -r \'1.0.0\' \'1.1.0\'', $changed->getCommand());
+        $this->assertEquals(
+            'git diff-tree --no-ext-diff --no-commit-id --name-only -r \'1.0.0\' \'1.1.0\'',
+            $changed->getCommand()
+        );
     }
 
     /**
@@ -44,6 +47,9 @@ class ChangedFilesTest extends TestCase
         $changed = new ChangedFiles();
         $changed->fromRevision('1.0.0');
 
-        $this->assertEquals('git diff-tree --no-commit-id --name-only -r \'1.0.0\'', $changed->getCommand());
+        $this->assertEquals(
+            'git diff-tree --no-ext-diff --no-commit-id --name-only -r \'1.0.0\'',
+            $changed->getCommand()
+        );
     }
 }


### PR DESCRIPTION
This PR includes several things:

* The `diff` commands now all have `--no-ext-diff` added to disallow the use of external diffing tools when running the command
* A new option to ignore submodules
* Fix bad parsing of the change position
* Implement `compareTo()` to create a working tree diff (and refactor `indexTo()`)

## Example

```php
use SebastianFeldmann\Git;

$repo = new Git\Repository(__DIR__);
$diff = $repo->getDiffOperator();
$workingTreeChanges = $diff->compareTo('HEAD');

foreach ($workingTreeChanges as $file) {
    echo "{$file->getName()} has " . count($file->getChanges());
    echo ' changes in the working tree' . PHP_EOL;
}
```

## Fix bad parsing of the change position

I found a bug in the way the change position is parsed. The previous regex for detecting and parsing this was:

    #^@@ (\-[0-9,]{3,} \+[0-9,]{3,}) @@ ?(.*)$#

This will only match lines like this:

    @@ -68,0 +83,2 @@

However, it won't match lines like:

    @@ -68 +83 @@

I updated both `Command\Diff\Compare\FullDiffList` and `Diff\Change` to parse a wider range of change positions.