### PR TITLE
Explicitly specify the diff algorithm to use

### DIFF
--- a/src/Command/Diff/Compare.php
+++ b/src/Command/Diff/Compare.php
@@ -191,7 +191,9 @@ class Compare extends Base
      */
     protected function getGitCommand(): string
     {
-        return 'diff --no-ext-diff'
+        return 'diff'
+               . ' --no-ext-diff'
+               . ' --diff-algorithm=myers'
                . $this->unified
                . $this->ignoreWhitespaces
                . $this->ignoreSubmodules

--- a/src/Command/DiffIndex/GetStagedFiles.php
+++ b/src/Command/DiffIndex/GetStagedFiles.php
@@ -31,6 +31,6 @@ class GetStagedFiles extends Base
      */
     protected function getGitCommand(): string
     {
-        return 'diff-index --no-ext-diff --cached --name-status HEAD';
+        return 'diff-index --diff-algorithm=myers --no-ext-diff --cached --name-status HEAD';
     }
 }

--- a/src/Command/DiffIndex/GetUnstagedPatch.php
+++ b/src/Command/DiffIndex/GetUnstagedPatch.php
@@ -63,6 +63,7 @@ class GetUnstagedPatch extends Base
     protected function getGitCommand(): string
     {
         return 'diff-index'
+            . ' --diff-algorithm=myers'
             . ' --ignore-submodules'
             . ' --binary'
             . ' --exit-code'

--- a/src/Command/DiffTree/ChangedFiles.php
+++ b/src/Command/DiffTree/ChangedFiles.php
@@ -61,7 +61,13 @@ class ChangedFiles extends Base
      */
     protected function getGitCommand(): string
     {
-        return 'diff-tree --no-ext-diff --no-commit-id --name-only -r ' . $this->getVersionsToCompare();
+        return 'diff-tree'
+            . ' --diff-algorithm=myers'
+            . ' --no-ext-diff'
+            . ' --no-commit-id'
+            . ' --name-only'
+            . ' -r'
+            . ' ' . $this->getVersionsToCompare();
     }
 
     /**

--- a/tests/git/Command/Diff/CompareTest.php
+++ b/tests/git/Command/Diff/CompareTest.php
@@ -31,7 +31,10 @@ class CompareTest extends TestCase
         $compare = new Compare();
         $compare->revisions('1.0.0', '1.1.0');
 
-        $this->assertEquals('git diff --no-ext-diff \'1.0.0\' \'1.1.0\' -- ', $compare->getCommand());
+        $this->assertEquals(
+            'git diff --no-ext-diff --diff-algorithm=myers \'1.0.0\' \'1.1.0\' -- ',
+            $compare->getCommand()
+        );
     }
 
     /**
@@ -43,7 +46,10 @@ class CompareTest extends TestCase
         $compare->revisions('1.0.0', '1.1.0');
         $compare->statsOnly();
 
-        $this->assertEquals('git diff --no-ext-diff --numstat \'1.0.0\' \'1.1.0\' -- ', $compare->getCommand());
+        $this->assertEquals(
+            'git diff --no-ext-diff --diff-algorithm=myers --numstat \'1.0.0\' \'1.1.0\' -- ',
+            $compare->getCommand()
+        );
     }
 
     /**
@@ -56,7 +62,7 @@ class CompareTest extends TestCase
         $compare->ignoreWhitespacesAtEndOfLine();
 
         $this->assertEquals(
-            'git diff --no-ext-diff --ignore-space-at-eol \'1.0.0\' \'1.1.0\' -- ',
+            'git diff --no-ext-diff --diff-algorithm=myers --ignore-space-at-eol \'1.0.0\' \'1.1.0\' -- ',
             $compare->getCommand()
         );
     }
@@ -69,7 +75,10 @@ class CompareTest extends TestCase
         $compare = new Compare();
         $compare->indexTo();
 
-        $this->assertEquals('git diff --no-ext-diff --staged \'HEAD\' -- ', $compare->getCommand());
+        $this->assertEquals(
+            'git diff --no-ext-diff --diff-algorithm=myers --staged \'HEAD\' -- ',
+            $compare->getCommand()
+        );
     }
 
     /**
@@ -81,7 +90,10 @@ class CompareTest extends TestCase
         $compare->indexTo()->withContextLines(2);
 
 
-        $this->assertEquals('git diff --no-ext-diff --unified=2 --staged \'HEAD\' -- ', $compare->getCommand());
+        $this->assertEquals(
+            'git diff --no-ext-diff --diff-algorithm=myers --unified=2 --staged \'HEAD\' -- ',
+            $compare->getCommand()
+        );
     }
 
     /**
@@ -93,7 +105,10 @@ class CompareTest extends TestCase
         $compare->revisions('1.0.0', '1.1.0');
         $compare->ignoreWhitespaces();
 
-        $this->assertEquals('git diff --no-ext-diff -w \'1.0.0\' \'1.1.0\' -- ', $compare->getCommand());
+        $this->assertEquals(
+            'git diff --no-ext-diff --diff-algorithm=myers -w \'1.0.0\' \'1.1.0\' -- ',
+            $compare->getCommand()
+        );
     }
 
     /**
@@ -107,7 +122,7 @@ class CompareTest extends TestCase
                 ->ignoreWhitespaces();
 
         $this->assertEquals(
-            'git diff --no-ext-diff -w --ignore-space-at-eol \'1.0.0\' \'1.1.0\' -- ',
+            'git diff --no-ext-diff --diff-algorithm=myers -w --ignore-space-at-eol \'1.0.0\' \'1.1.0\' -- ',
             $compare->getCommand()
         );
     }
@@ -117,7 +132,10 @@ class CompareTest extends TestCase
         $compare = new Compare();
         $compare->ignoreSubmodules();
 
-        $this->assertEquals('git diff --no-ext-diff --ignore-submodules  -- ', $compare->getCommand());
+        $this->assertEquals(
+            'git diff --no-ext-diff --diff-algorithm=myers --ignore-submodules  -- ',
+            $compare->getCommand()
+        );
     }
 
     public function testStaged(): void
@@ -125,7 +143,10 @@ class CompareTest extends TestCase
         $compare = new Compare();
         $compare->staged();
 
-        $this->assertEquals('git diff --no-ext-diff --staged  -- ', $compare->getCommand());
+        $this->assertEquals(
+            'git diff --no-ext-diff --diff-algorithm=myers --staged  -- ',
+            $compare->getCommand()
+        );
     }
 
     public function testToWithDefaultParam(): void
@@ -133,7 +154,10 @@ class CompareTest extends TestCase
         $compare = new Compare();
         $compare->to();
 
-        $this->assertEquals('git diff --no-ext-diff \'HEAD\' -- ', $compare->getCommand());
+        $this->assertEquals(
+            'git diff --no-ext-diff --diff-algorithm=myers \'HEAD\' -- ',
+            $compare->getCommand()
+        );
     }
 
     public function testToWithPassedParam(): void
@@ -141,6 +165,9 @@ class CompareTest extends TestCase
         $compare = new Compare();
         $compare->to('foobar');
 
-        $this->assertEquals('git diff --no-ext-diff \'foobar\' -- ', $compare->getCommand());
+        $this->assertEquals(
+            'git diff --no-ext-diff --diff-algorithm=myers \'foobar\' -- ',
+            $compare->getCommand()
+        );
     }
 }

--- a/tests/git/Command/DiffIndex/GetStagedFilesTest.php
+++ b/tests/git/Command/DiffIndex/GetStagedFilesTest.php
@@ -31,6 +31,6 @@ class GetStagedFilesTest extends TestCase
         $cmd = new GetStagedFiles();
         $exe = $cmd->getCommand();
 
-        $this->assertEquals('git diff-index --no-ext-diff --cached --name-status HEAD', $exe);
+        $this->assertEquals('git diff-index --diff-algorithm=myers --no-ext-diff --cached --name-status HEAD', $exe);
     }
 }

--- a/tests/git/Command/DiffIndex/GetUnstagedPatchTest.php
+++ b/tests/git/Command/DiffIndex/GetUnstagedPatchTest.php
@@ -35,7 +35,8 @@ class GetUnstagedPatchTest extends TestCase
         $cmd = new GetUnstagedPatch();
 
         $this->assertSame(
-            'git diff-index --ignore-submodules --binary --exit-code --no-color --no-ext-diff -- ',
+            'git diff-index --diff-algorithm=myers --ignore-submodules '
+            . '--binary --exit-code --no-color --no-ext-diff -- ',
             $cmd->getCommand()
         );
     }
@@ -45,7 +46,8 @@ class GetUnstagedPatchTest extends TestCase
         $cmd = (new GetUnstagedPatch())->tree('1234567890');
 
         $this->assertSame(
-            'git diff-index --ignore-submodules --binary --exit-code --no-color --no-ext-diff \'1234567890\' -- ',
+            'git diff-index --diff-algorithm=myers --ignore-submodules '
+            . '--binary --exit-code --no-color --no-ext-diff \'1234567890\' -- ',
             $cmd->getCommand()
         );
     }

--- a/tests/git/Command/DiffTree/ChangedFilesTest.php
+++ b/tests/git/Command/DiffTree/ChangedFilesTest.php
@@ -34,7 +34,7 @@ class ChangedFilesTest extends TestCase
                 ->toRevision('1.1.0');
 
         $this->assertEquals(
-            'git diff-tree --no-ext-diff --no-commit-id --name-only -r \'1.0.0\' \'1.1.0\'',
+            'git diff-tree --diff-algorithm=myers --no-ext-diff --no-commit-id --name-only -r \'1.0.0\' \'1.1.0\'',
             $changed->getCommand()
         );
     }
@@ -48,7 +48,7 @@ class ChangedFilesTest extends TestCase
         $changed->fromRevision('1.0.0');
 
         $this->assertEquals(
-            'git diff-tree --no-ext-diff --no-commit-id --name-only -r \'1.0.0\'',
+            'git diff-tree --diff-algorithm=myers --no-ext-diff --no-commit-id --name-only -r \'1.0.0\'',
             $changed->getCommand()
         );
     }


### PR DESCRIPTION
I was tinkering around with something and realized that, if someone has `diff.algorithm` set to something other than the default, the output could be different than any of the assumptions made by this library, so it's probably best to explicitly set the algorithm to the current default (a.k.a. "myers").

(I haven't noticed any cases where using a different algorithm causes any problems. I'm submitting this in the case that it *could* cause a problem.)