### PR TITLE
Detect squash and fixup commits

### DIFF
--- a/src/CommitMessage.php
+++ b/src/CommitMessage.php
@@ -109,6 +109,25 @@ class CommitMessage
         return empty($this->content);
     }
 
+    /**
+     * Is this a fixup commit
+     *
+     * @return bool
+     */
+    public function isFixup(): bool
+    {
+        return strpos($this->rawContent, 'fixup!') === 0;
+    }
+
+    /**
+     * Is this a squash commit
+     *
+     * @return bool
+     */
+    public function isSquash(): bool
+    {
+        return  strpos($this->rawContent, 'squash!') === 0;
+    }
 
     /**
      * Get commit message content

--- a/tests/git/CommitMessageTest.php
+++ b/tests/git/CommitMessageTest.php
@@ -34,6 +34,30 @@ class CommitMessageTest extends TestCase
     }
 
     /**
+     * Tests CommitMessage::isFixup
+     */
+    public function testIsFixup()
+    {
+        $msg = new CommitMessage('Some stuff');
+        $this->assertFalse($msg->isFixup());
+
+        $msg = new CommitMessage('fixup! Some stuff');
+        $this->assertTrue($msg->isFixup());
+    }
+
+    /**
+     * Tests CommitMessage::isSquash
+     */
+    public function testIsSquash()
+    {
+        $msg = new CommitMessage('Some stuff');
+        $this->assertFalse($msg->isSquash());
+
+        $msg = new CommitMessage('squash! Some stuff');
+        $this->assertTrue($msg->isSquash());
+    }
+
+    /**
      * Tests CommitMessage::getSubject
      */
     public function testGetSubjectOnEmptyMessage()


### PR DESCRIPTION
This allows the user to check if a commit message is indicating a squash or a fixup commit.